### PR TITLE
Configure snowflake openflow for npi data

### DIFF
--- a/default/NPI.json
+++ b/default/NPI.json
@@ -1,0 +1,7805 @@
+{
+  "externalControllerServices" : { },
+  "flow" : {
+    "createdTimestamp" : 1753953462349,
+    "description" : "NPI Data Replication",
+    "identifier" : "NPI",
+    "lastModifiedTimestamp" : 1753953462349,
+    "name" : "NPI",
+    "versionCount" : 0
+  },
+  "flowContents" : {
+    "comments" : "0.16.0-0e43eaf",
+    "componentType" : "PROCESS_GROUP",
+    "connections" : [ ],
+    "controllerServices" : [ {
+      "bulletinLevel" : "WARN",
+      "bundle" : {
+        "artifact" : "runtime-database-cdc-services-nar",
+        "group" : "com.snowflake.openflow.runtime",
+        "version" : "2025.7.24.18"
+      },
+      "comments" : "Keeps a list of table column filters, to include or exclude certain columns from replication.",
+      "componentType" : "CONTROLLER_SERVICE",
+      "controllerServiceApis" : [ {
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-services-api-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "type" : "com.snowflake.openflow.runtime.services.database.schema.TableColumnFilterService"
+      } ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "1d805b66-4a8a-3fb2-a7c9-0876eb122423",
+      "name" : "Table Column Filter",
+      "properties" : {
+        "Filter JSON" : "#{Column Filter JSON}"
+      },
+      "propertyDescriptors" : {
+        "Filter JSON" : {
+          "displayName" : "Filter JSON",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Filter JSON",
+          "sensitive" : false
+        }
+      },
+      "scheduledState" : "DISABLED",
+      "type" : "com.snowflake.openflow.runtime.services.database.schema.JsonTableColumnFilter"
+    }, {
+      "bulletinLevel" : "WARN",
+      "bundle" : {
+        "artifact" : "nifi-record-serialization-services-nar",
+        "group" : "org.apache.nifi",
+        "version" : "2025.7.24.18"
+      },
+      "comments" : "Used to deserialize database rows from FlowFiles.",
+      "componentType" : "CONTROLLER_SERVICE",
+      "controllerServiceApis" : [ {
+        "bundle" : {
+          "artifact" : "nifi-standard-services-api-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "type" : "org.apache.nifi.serialization.RecordReaderFactory"
+      } ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "24cdd13f-c206-3d50-bfc2-d29011a189ca",
+      "name" : "JSON Reader",
+      "properties" : {
+        "Max String Length" : "20 MB",
+        "schema-application-strategy" : "SELECTED_PART",
+        "schema-name" : "${schema.name}",
+        "starting-field-strategy" : "ROOT_NODE",
+        "schema-access-strategy" : "schema-text-property",
+        "schema-text" : "${avro.schema}",
+        "Allow Comments" : "false"
+      },
+      "propertyDescriptors" : {
+        "schema-reference-reader" : {
+          "displayName" : "Schema Reference Reader",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "schema-reference-reader",
+          "sensitive" : false
+        },
+        "schema-branch" : {
+          "displayName" : "Schema Branch",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-branch",
+          "sensitive" : false
+        },
+        "Max String Length" : {
+          "displayName" : "Max String Length",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Max String Length",
+          "sensitive" : false
+        },
+        "schema-application-strategy" : {
+          "displayName" : "Schema Application Strategy",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-application-strategy",
+          "sensitive" : false
+        },
+        "Timestamp Format" : {
+          "displayName" : "Timestamp Format",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Timestamp Format",
+          "sensitive" : false
+        },
+        "schema-inference-cache" : {
+          "displayName" : "Schema Inference Cache",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "schema-inference-cache",
+          "sensitive" : false
+        },
+        "Date Format" : {
+          "displayName" : "Date Format",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Date Format",
+          "sensitive" : false
+        },
+        "schema-name" : {
+          "displayName" : "Schema Name",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-name",
+          "sensitive" : false
+        },
+        "starting-field-strategy" : {
+          "displayName" : "Starting Field Strategy",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "starting-field-strategy",
+          "sensitive" : false
+        },
+        "schema-registry" : {
+          "displayName" : "Schema Registry",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "schema-registry",
+          "sensitive" : false
+        },
+        "starting-field-name" : {
+          "displayName" : "Starting Field Name",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "starting-field-name",
+          "sensitive" : false
+        },
+        "Time Format" : {
+          "displayName" : "Time Format",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Time Format",
+          "sensitive" : false
+        },
+        "schema-access-strategy" : {
+          "displayName" : "Schema Access Strategy",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-access-strategy",
+          "sensitive" : false
+        },
+        "schema-version" : {
+          "displayName" : "Schema Version",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-version",
+          "sensitive" : false
+        },
+        "schema-text" : {
+          "displayName" : "Schema Text",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-text",
+          "sensitive" : false
+        },
+        "Allow Comments" : {
+          "displayName" : "Allow Comments",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Allow Comments",
+          "sensitive" : false
+        }
+      },
+      "scheduledState" : "DISABLED",
+      "type" : "org.apache.nifi.json.JsonTreeReader"
+    }, {
+      "bulletinLevel" : "WARN",
+      "bundle" : {
+        "artifact" : "nifi-record-serialization-services-nar",
+        "group" : "org.apache.nifi",
+        "version" : "2025.7.24.18"
+      },
+      "comments" : "Used to serialize database rows into FlowFiles.",
+      "componentType" : "CONTROLLER_SERVICE",
+      "controllerServiceApis" : [ {
+        "bundle" : {
+          "artifact" : "nifi-standard-services-api-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "type" : "org.apache.nifi.serialization.RecordSetWriterFactory"
+      } ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "50c96126-f1cd-3111-9aad-4b47b2856551",
+      "name" : "JSON Writer",
+      "properties" : {
+        "Allow Scientific Notation" : "true",
+        "compression-level" : "1",
+        "Pretty Print JSON" : "false",
+        "compression-format" : "none",
+        "Schema Write Strategy" : "full-schema-attribute",
+        "suppress-nulls" : "never-suppress",
+        "output-grouping" : "output-oneline",
+        "schema-name" : "${schema.name}",
+        "schema-access-strategy" : "inherit-record-schema",
+        "schema-text" : "${avro.schema}"
+      },
+      "propertyDescriptors" : {
+        "schema-reference-reader" : {
+          "displayName" : "Schema Reference Reader",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "schema-reference-reader",
+          "sensitive" : false
+        },
+        "schema-branch" : {
+          "displayName" : "Schema Branch",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-branch",
+          "sensitive" : false
+        },
+        "Allow Scientific Notation" : {
+          "displayName" : "Allow Scientific Notation",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Allow Scientific Notation",
+          "sensitive" : false
+        },
+        "compression-level" : {
+          "displayName" : "Compression Level",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "compression-level",
+          "sensitive" : false
+        },
+        "schema-cache" : {
+          "displayName" : "Schema Cache",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "schema-cache",
+          "sensitive" : false
+        },
+        "Timestamp Format" : {
+          "displayName" : "Timestamp Format",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Timestamp Format",
+          "sensitive" : false
+        },
+        "Date Format" : {
+          "displayName" : "Date Format",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Date Format",
+          "sensitive" : false
+        },
+        "Pretty Print JSON" : {
+          "displayName" : "Pretty Print JSON",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Pretty Print JSON",
+          "sensitive" : false
+        },
+        "compression-format" : {
+          "displayName" : "Compression Format",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "compression-format",
+          "sensitive" : false
+        },
+        "Schema Write Strategy" : {
+          "displayName" : "Schema Write Strategy",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Schema Write Strategy",
+          "sensitive" : false
+        },
+        "suppress-nulls" : {
+          "displayName" : "Suppress Null Values",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "suppress-nulls",
+          "sensitive" : false
+        },
+        "output-grouping" : {
+          "displayName" : "Output Grouping",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "output-grouping",
+          "sensitive" : false
+        },
+        "schema-name" : {
+          "displayName" : "Schema Name",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-name",
+          "sensitive" : false
+        },
+        "schema-registry" : {
+          "displayName" : "Schema Registry",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "schema-registry",
+          "sensitive" : false
+        },
+        "Time Format" : {
+          "displayName" : "Time Format",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Time Format",
+          "sensitive" : false
+        },
+        "schema-access-strategy" : {
+          "displayName" : "Schema Access Strategy",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-access-strategy",
+          "sensitive" : false
+        },
+        "schema-version" : {
+          "displayName" : "Schema Version",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-version",
+          "sensitive" : false
+        },
+        "schema-text" : {
+          "displayName" : "Schema Text",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "schema-text",
+          "sensitive" : false
+        },
+        "Schema Reference Writer" : {
+          "displayName" : "Schema Reference Writer",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "Schema Reference Writer",
+          "sensitive" : false
+        }
+      },
+      "scheduledState" : "DISABLED",
+      "type" : "org.apache.nifi.json.JsonRecordSetWriter"
+    }, {
+      "bulletinLevel" : "WARN",
+      "bundle" : {
+        "artifact" : "runtime-snowflake-connection-service-nar",
+        "group" : "com.snowflake.openflow.runtime",
+        "version" : "2025.7.24.18"
+      },
+      "comments" : "",
+      "componentType" : "CONTROLLER_SERVICE",
+      "controllerServiceApis" : [ {
+        "bundle" : {
+          "artifact" : "nifi-standard-services-api-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "type" : "org.apache.nifi.dbcp.DBCPService"
+      } ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+      "name" : "Snowflake Connection Pool",
+      "properties" : {
+        "Account" : "#{Snowflake Account Identifier}",
+        "Warehouse" : "#{Snowflake Warehouse}",
+        "User" : "#{Snowflake Username}",
+        "Maximum Connections" : "10",
+        "Maximum Lifetime" : "30 minutes",
+        "Private Key Service" : "a9d0fce7-8560-33f6-8ed0-992949862808",
+        "Connection Strategy" : "STANDARD",
+        "Connection Timeout" : "30 seconds",
+        "Role" : "#{Snowflake Role}",
+        "Idle Timeout" : "10 minutes",
+        "Authentication Strategy" : "#{Snowflake Authentication Strategy}",
+        "Database Name" : "DATA_NPI"
+      },
+      "propertyDescriptors" : {
+        "Account" : {
+          "displayName" : "Account",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Account",
+          "sensitive" : false
+        },
+        "Warehouse" : {
+          "displayName" : "Warehouse",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Warehouse",
+          "sensitive" : false
+        },
+        "User" : {
+          "displayName" : "User",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "User",
+          "sensitive" : false
+        },
+        "Maximum Connections" : {
+          "displayName" : "Maximum Connections",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Maximum Connections",
+          "sensitive" : false
+        },
+        "Maximum Lifetime" : {
+          "displayName" : "Maximum Lifetime",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Maximum Lifetime",
+          "sensitive" : false
+        },
+        "Schema" : {
+          "displayName" : "Schema",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Schema",
+          "sensitive" : false
+        },
+        "Private Key Service" : {
+          "displayName" : "Private Key Service",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "Private Key Service",
+          "sensitive" : false
+        },
+        "Connection Strategy" : {
+          "displayName" : "Connection Strategy",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Connection Strategy",
+          "sensitive" : false
+        },
+        "Connection Timeout" : {
+          "displayName" : "Connection Timeout",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Connection Timeout",
+          "sensitive" : false
+        },
+        "Role" : {
+          "displayName" : "Role",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Role",
+          "sensitive" : false
+        },
+        "Idle Timeout" : {
+          "displayName" : "Idle Timeout",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Idle Timeout",
+          "sensitive" : false
+        },
+        "Authentication Strategy" : {
+          "displayName" : "Authentication Strategy",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Authentication Strategy",
+          "sensitive" : false
+        },
+        "Database Name" : {
+          "displayName" : "Database Name",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Database Name",
+          "sensitive" : false
+        },
+        "Password" : {
+          "displayName" : "Password",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Password",
+          "sensitive" : true
+        }
+      },
+      "scheduledState" : "DISABLED",
+      "type" : "com.snowflake.openflow.runtime.services.snowflake.SnowflakeConnectionService"
+    }, {
+      "bulletinLevel" : "WARN",
+      "bundle" : {
+        "artifact" : "runtime-database-cdc-services-nar",
+        "group" : "com.snowflake.openflow.runtime",
+        "version" : "2025.7.24.18"
+      },
+      "comments" : "Keeps a register of the latest source table schemas to compare against incoming DDL events from the CDC stream.",
+      "componentType" : "CONTROLLER_SERVICE",
+      "controllerServiceApis" : [ {
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-services-api-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "type" : "com.snowflake.openflow.runtime.services.database.schema.CdcSchemaRegistry"
+      } ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+      "name" : "Source Table Schema Registry",
+      "properties" : { },
+      "propertyDescriptors" : { },
+      "scheduledState" : "DISABLED",
+      "type" : "com.snowflake.openflow.runtime.services.database.schema.StateManagedCdcSchemaRegistry"
+    }, {
+      "bulletinLevel" : "WARN",
+      "bundle" : {
+        "artifact" : "nifi-dbcp-service-nar",
+        "group" : "org.apache.nifi",
+        "version" : "2025.7.24.18"
+      },
+      "comments" : "",
+      "componentType" : "CONTROLLER_SERVICE",
+      "controllerServiceApis" : [ {
+        "bundle" : {
+          "artifact" : "nifi-standard-services-api-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "type" : "org.apache.nifi.dbcp.DBCPService"
+      } ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "a7df0df5-64ea-391c-9990-5b089d4eea95",
+      "name" : "SQLServer Connection Pool",
+      "properties" : {
+        "dbcp-min-idle-conns" : "0",
+        "Max Wait Time" : "500 millis",
+        "Database Driver Class Name" : "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+        "dbcp-min-evictable-idle-time" : "30 mins",
+        "Max Total Connections" : "8",
+        "dbcp-max-conn-lifetime" : "-1",
+        "Database Connection URL" : "#{SQLServer Connection URL}",
+        "dbcp-time-between-eviction-runs" : "-1",
+        "Database User" : "#{SQLServer Username}",
+        "dbcp-soft-min-evictable-idle-time" : "-1",
+        "database-driver-locations" : "#{SQLServer JDBC Driver}",
+        "dbcp-max-idle-conns" : "8",
+        "Password" : "#{SQLServer Password}"
+      },
+      "propertyDescriptors" : {
+        "dbcp-min-idle-conns" : {
+          "displayName" : "Minimum Idle Connections",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "dbcp-min-idle-conns",
+          "sensitive" : false
+        },
+        "Max Wait Time" : {
+          "displayName" : "Max Wait Time",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Max Wait Time",
+          "sensitive" : false
+        },
+        "Database Driver Class Name" : {
+          "displayName" : "Database Driver Class Name",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Database Driver Class Name",
+          "sensitive" : false
+        },
+        "dbcp-min-evictable-idle-time" : {
+          "displayName" : "Minimum Evictable Idle Time",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "dbcp-min-evictable-idle-time",
+          "sensitive" : false
+        },
+        "Max Total Connections" : {
+          "displayName" : "Max Total Connections",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Max Total Connections",
+          "sensitive" : false
+        },
+        "dbcp-max-conn-lifetime" : {
+          "displayName" : "Max Connection Lifetime",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "dbcp-max-conn-lifetime",
+          "sensitive" : false
+        },
+        "Validation-query" : {
+          "displayName" : "Validation query",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Validation-query",
+          "sensitive" : false
+        },
+        "Database Connection URL" : {
+          "displayName" : "Database Connection URL",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Database Connection URL",
+          "sensitive" : false
+        },
+        "dbcp-time-between-eviction-runs" : {
+          "displayName" : "Time Between Eviction Runs",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "dbcp-time-between-eviction-runs",
+          "sensitive" : false
+        },
+        "Database User" : {
+          "displayName" : "Database User",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Database User",
+          "sensitive" : false
+        },
+        "kerberos-user-service" : {
+          "displayName" : "Kerberos User Service",
+          "dynamic" : false,
+          "identifiesControllerService" : true,
+          "name" : "kerberos-user-service",
+          "sensitive" : false
+        },
+        "dbcp-soft-min-evictable-idle-time" : {
+          "displayName" : "Soft Minimum Evictable Idle Time",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "dbcp-soft-min-evictable-idle-time",
+          "sensitive" : false
+        },
+        "database-driver-locations" : {
+          "displayName" : "Database Driver Location(s)",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "database-driver-locations",
+          "resourceDefinition" : {
+            "cardinality" : "MULTIPLE",
+            "resourceTypes" : [ "DIRECTORY", "FILE", "URL" ]
+          },
+          "sensitive" : false
+        },
+        "dbcp-max-idle-conns" : {
+          "displayName" : "Max Idle Connections",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "dbcp-max-idle-conns",
+          "sensitive" : false
+        },
+        "Password" : {
+          "displayName" : "Password",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "Password",
+          "sensitive" : true
+        }
+      },
+      "scheduledState" : "DISABLED",
+      "type" : "org.apache.nifi.dbcp.DBCPConnectionPool"
+    }, {
+      "bulletinLevel" : "WARN",
+      "bundle" : {
+        "artifact" : "nifi-key-service-nar",
+        "group" : "org.apache.nifi",
+        "version" : "2025.7.24.18"
+      },
+      "comments" : "",
+      "componentType" : "CONTROLLER_SERVICE",
+      "controllerServiceApis" : [ {
+        "bundle" : {
+          "artifact" : "nifi-standard-services-api-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "type" : "org.apache.nifi.key.service.api.PrivateKeyService"
+      } ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "a9d0fce7-8560-33f6-8ed0-992949862808",
+      "name" : "Snowflake Private Key Service",
+      "properties" : {
+        "key-password" : "#{Snowflake Private Key Password}",
+        "key-file" : "#{Snowflake Private Key File}",
+        "key" : "#{Snowflake Private Key}"
+      },
+      "propertyDescriptors" : {
+        "key-password" : {
+          "displayName" : "Key Password",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "key-password",
+          "sensitive" : true
+        },
+        "key-file" : {
+          "displayName" : "Key File",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "key-file",
+          "resourceDefinition" : {
+            "cardinality" : "SINGLE",
+            "resourceTypes" : [ "FILE" ]
+          },
+          "sensitive" : false
+        },
+        "key" : {
+          "displayName" : "Key",
+          "dynamic" : false,
+          "identifiesControllerService" : false,
+          "name" : "key",
+          "sensitive" : true
+        }
+      },
+      "scheduledState" : "DISABLED",
+      "type" : "org.apache.nifi.key.service.StandardPrivateKeyService"
+    }, {
+      "bulletinLevel" : "WARN",
+      "bundle" : {
+        "artifact" : "runtime-database-cdc-services-nar",
+        "group" : "com.snowflake.openflow.runtime",
+        "version" : "2025.7.24.18"
+      },
+      "comments" : "Keeps a list of tables under replication, and the stage of replication they're in.",
+      "componentType" : "CONTROLLER_SERVICE",
+      "controllerServiceApis" : [ {
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-services-api-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "type" : "com.snowflake.openflow.runtime.state.TableStateService"
+      } ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+      "name" : "Table State Store",
+      "properties" : { },
+      "propertyDescriptors" : { },
+      "scheduledState" : "DISABLED",
+      "type" : "com.snowflake.openflow.runtime.services.state.StandardTableStateService"
+    } ],
+    "defaultBackPressureDataSizeThreshold" : "1 GB",
+    "defaultBackPressureObjectThreshold" : 10000,
+    "defaultFlowFileExpiration" : "0 sec",
+    "executionEngine" : "INHERITED",
+    "externalControllerServiceReferences" : { },
+    "flowFileConcurrency" : "UNBOUNDED",
+    "flowFileOutboundPolicy" : "STREAM_WHEN_AVAILABLE",
+    "funnels" : [ ],
+    "identifier" : "flow-contents-group",
+    "inputPorts" : [ ],
+    "labels" : [ ],
+    "maxConcurrentTasks" : 1,
+    "name" : "NPI",
+    "outputPorts" : [ ],
+    "parameterContextName" : "SQLServer Ingestion Parameters (2)",
+    "position" : {
+      "x" : 0.0,
+      "y" : 0.0
+    },
+    "processGroups" : [ {
+      "comments" : "Prevents streams on Journal tables to become stale when data is not actively pushed within the data retention period. See https://docs.snowflake.com/en/user-guide/streams-intro#data-retention-period-and-staleness   ",
+      "componentType" : "PROCESS_GROUP",
+      "connections" : [ {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "",
+          "groupId" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+          "id" : "5dd4b5c5-0197-1000-2242-98db6993d791",
+          "name" : "Get Stream Coordinates",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+        "identifier" : "5dd4b5c6-0197-1000-4db8-746a4d9280b6",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "Journal Streams Present" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+          "id" : "5dd4b5c2-0197-1000-087d-62567280fe5f",
+          "name" : "Check If Journal Streams Are Present",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 3
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "",
+          "groupId" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+          "id" : "5dd4b5c3-0197-1000-721a-39dc2937dd95",
+          "name" : "Advance Stream's STALE_AFTER",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+        "identifier" : "5dd4b5c7-0197-1000-d82c-182b1d004069",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "matched" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+          "id" : "5dd4b5c5-0197-1000-2242-98db6993d791",
+          "name" : "Get Stream Coordinates",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 1
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "",
+          "groupId" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+          "id" : "5dd4b5c2-0197-1000-087d-62567280fe5f",
+          "name" : "Check If Journal Streams Are Present",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+        "identifier" : "5dd4b5c8-0197-1000-6595-46d84f31283a",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+          "id" : "5dd4b5c4-0197-1000-d508-9b80d61e5b99",
+          "name" : "Fetch Journal Streams",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 2
+      } ],
+      "controllerServices" : [ ],
+      "defaultBackPressureDataSizeThreshold" : "1 GB",
+      "defaultBackPressureObjectThreshold" : 10000,
+      "defaultFlowFileExpiration" : "0 sec",
+      "executionEngine" : "INHERITED",
+      "flowFileConcurrency" : "UNBOUNDED",
+      "flowFileOutboundPolicy" : "STREAM_WHEN_AVAILABLE",
+      "funnels" : [ ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+      "inputPorts" : [ ],
+      "labels" : [ ],
+      "maxConcurrentTasks" : 1,
+      "name" : "Stream Staleness Prevention",
+      "outputPorts" : [ ],
+      "parameterContextName" : "SQLServer Ingestion Parameters (2)",
+      "position" : {
+        "x" : -936.0,
+        "y" : 184.0
+      },
+      "processGroups" : [ ],
+      "processors" : [ {
+        "autoTerminatedRelationships" : [ "unmatched" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-standard-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+        "identifier" : "5dd4b5c2-0197-1000-087d-62567280fe5f",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Check If Journal Streams Are Present",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -216.0,
+          "y" : -488.0
+        },
+        "properties" : {
+          "Routing Strategy" : "Route to Property name",
+          "Journal Streams Present" : "${executesql.row.count:gt(0)}"
+        },
+        "propertyDescriptors" : {
+          "Routing Strategy" : {
+            "displayName" : "Routing Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Routing Strategy",
+            "sensitive" : false
+          },
+          "Journal Streams Present" : {
+            "displayName" : "Journal Streams Present",
+            "dynamic" : true,
+            "identifiesControllerService" : false,
+            "name" : "Journal Streams Present",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 25,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.standard.RouteOnAttribute",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "failure", "success" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-standard-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+        "identifier" : "5dd4b5c3-0197-1000-721a-39dc2937dd95",
+        "maxBackoffPeriod" : "5 mins",
+        "name" : "Advance Stream's STALE_AFTER",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -216.0,
+          "y" : -40.0
+        },
+        "properties" : {
+          "esql-max-rows" : "0",
+          "dbf-default-precision" : "10",
+          "Max Wait Time" : "0 seconds",
+          "SQL Query" : "select SYSTEM$STREAM_HAS_DATA('\\\"${databaseName}\\\".\\\"${schemaName}\\\".\\\"${streamName}\\\"') as result",
+          "Database Connection Pooling Service" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+          "esql-auto-commit" : "true",
+          "dbf-user-logical-types" : "false",
+          "dbf-default-scale" : "0",
+          "compression-format" : "NONE",
+          "esql-output-batch-size" : "0",
+          "esql-fetch-size" : "0",
+          "dbf-normalize" : "false",
+          "Content Output Strategy" : "EMPTY"
+        },
+        "propertyDescriptors" : {
+          "esql-max-rows" : {
+            "displayName" : "Max Rows Per Flow File",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esql-max-rows",
+            "sensitive" : false
+          },
+          "dbf-default-precision" : {
+            "displayName" : "Default Decimal Precision",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "dbf-default-precision",
+            "sensitive" : false
+          },
+          "Max Wait Time" : {
+            "displayName" : "Max Wait Time",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Wait Time",
+            "sensitive" : false
+          },
+          "SQL Query" : {
+            "displayName" : "SQL Query",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "SQL Query",
+            "sensitive" : false
+          },
+          "Database Connection Pooling Service" : {
+            "displayName" : "Database Connection Pooling Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Database Connection Pooling Service",
+            "sensitive" : false
+          },
+          "sql-post-query" : {
+            "displayName" : "SQL Post-Query",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "sql-post-query",
+            "sensitive" : false
+          },
+          "esql-auto-commit" : {
+            "displayName" : "Set Auto Commit",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esql-auto-commit",
+            "sensitive" : false
+          },
+          "dbf-user-logical-types" : {
+            "displayName" : "Use Avro Logical Types",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "dbf-user-logical-types",
+            "sensitive" : false
+          },
+          "dbf-default-scale" : {
+            "displayName" : "Default Decimal Scale",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "dbf-default-scale",
+            "sensitive" : false
+          },
+          "sql-pre-query" : {
+            "displayName" : "SQL Pre-Query",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "sql-pre-query",
+            "sensitive" : false
+          },
+          "compression-format" : {
+            "displayName" : "Compression Format",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "compression-format",
+            "sensitive" : false
+          },
+          "esql-output-batch-size" : {
+            "displayName" : "Output Batch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esql-output-batch-size",
+            "sensitive" : false
+          },
+          "esql-fetch-size" : {
+            "displayName" : "Fetch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esql-fetch-size",
+            "sensitive" : false
+          },
+          "dbf-normalize" : {
+            "displayName" : "Normalize Table/Column Names",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "dbf-normalize",
+            "sensitive" : false
+          },
+          "Content Output Strategy" : {
+            "displayName" : "Content Output Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Content Output Strategy",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ "failure" ],
+        "retryCount" : 100,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.standard.ExecuteSQL",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "failure" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-standard-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+        "identifier" : "5dd4b5c4-0197-1000-d508-9b80d61e5b99",
+        "maxBackoffPeriod" : "5 mins",
+        "name" : "Fetch Journal Streams",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -216.0,
+          "y" : -680.0
+        },
+        "properties" : {
+          "esql-max-rows" : "1",
+          "esqlrecord-record-writer" : "50c96126-f1cd-3111-9aad-4b47b2856551",
+          "dbf-default-precision" : "10",
+          "Max Wait Time" : "0 seconds",
+          "SQL Query" : "SHOW STREAMS like '%journal%' IN DATABASE DATA_NPI",
+          "Database Connection Pooling Service" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+          "esql-auto-commit" : "true",
+          "dbf-user-logical-types" : "false",
+          "dbf-default-scale" : "0",
+          "esql-output-batch-size" : "0",
+          "esql-fetch-size" : "0",
+          "esqlrecord-normalize" : "false"
+        },
+        "propertyDescriptors" : {
+          "esql-max-rows" : {
+            "displayName" : "Max Rows Per Flow File",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esql-max-rows",
+            "sensitive" : false
+          },
+          "esqlrecord-record-writer" : {
+            "displayName" : "Record Writer",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "esqlrecord-record-writer",
+            "sensitive" : false
+          },
+          "dbf-default-precision" : {
+            "displayName" : "Default Decimal Precision",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "dbf-default-precision",
+            "sensitive" : false
+          },
+          "Max Wait Time" : {
+            "displayName" : "Max Wait Time",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Wait Time",
+            "sensitive" : false
+          },
+          "SQL Query" : {
+            "displayName" : "SQL Query",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "SQL Query",
+            "sensitive" : false
+          },
+          "Database Connection Pooling Service" : {
+            "displayName" : "Database Connection Pooling Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Database Connection Pooling Service",
+            "sensitive" : false
+          },
+          "sql-post-query" : {
+            "displayName" : "SQL Post-Query",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "sql-post-query",
+            "sensitive" : false
+          },
+          "esql-auto-commit" : {
+            "displayName" : "Set Auto Commit",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esql-auto-commit",
+            "sensitive" : false
+          },
+          "dbf-user-logical-types" : {
+            "displayName" : "Use Avro Logical Types",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "dbf-user-logical-types",
+            "sensitive" : false
+          },
+          "dbf-default-scale" : {
+            "displayName" : "Default Decimal Scale",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "dbf-default-scale",
+            "sensitive" : false
+          },
+          "sql-pre-query" : {
+            "displayName" : "SQL Pre-Query",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "sql-pre-query",
+            "sensitive" : false
+          },
+          "esql-output-batch-size" : {
+            "displayName" : "Output Batch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esql-output-batch-size",
+            "sensitive" : false
+          },
+          "esql-fetch-size" : {
+            "displayName" : "Fetch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esql-fetch-size",
+            "sensitive" : false
+          },
+          "esqlrecord-normalize" : {
+            "displayName" : "Normalize Table/Column Names",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "esqlrecord-normalize",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ "failure" ],
+        "retryCount" : 100,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "24 hours",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.standard.ExecuteSQLRecord",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "failure", "unmatched" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-standard-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "5dd4b5c1-0197-1000-efed-43a7f20ff1f4",
+        "identifier" : "5dd4b5c5-0197-1000-2242-98db6993d791",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Get Stream Coordinates",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -216.0,
+          "y" : -272.0
+        },
+        "properties" : {
+          "Destination" : "flowfile-attribute",
+          "databaseName" : "$.database_name",
+          "Max String Length" : "20 MB",
+          "Return Type" : "auto-detect",
+          "Null Value Representation" : "empty string",
+          "schemaName" : "$.schema_name",
+          "streamName" : "$.name",
+          "Path Not Found Behavior" : "ignore"
+        },
+        "propertyDescriptors" : {
+          "Destination" : {
+            "displayName" : "Destination",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Destination",
+            "sensitive" : false
+          },
+          "databaseName" : {
+            "displayName" : "databaseName",
+            "dynamic" : true,
+            "identifiesControllerService" : false,
+            "name" : "databaseName",
+            "sensitive" : false
+          },
+          "Max String Length" : {
+            "displayName" : "Max String Length",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max String Length",
+            "sensitive" : false
+          },
+          "Return Type" : {
+            "displayName" : "Return Type",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Return Type",
+            "sensitive" : false
+          },
+          "Null Value Representation" : {
+            "displayName" : "Null Value Representation",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Null Value Representation",
+            "sensitive" : false
+          },
+          "schemaName" : {
+            "displayName" : "schemaName",
+            "dynamic" : true,
+            "identifiesControllerService" : false,
+            "name" : "schemaName",
+            "sensitive" : false
+          },
+          "streamName" : {
+            "displayName" : "streamName",
+            "dynamic" : true,
+            "identifiesControllerService" : false,
+            "name" : "streamName",
+            "sensitive" : false
+          },
+          "Path Not Found Behavior" : {
+            "displayName" : "Path Not Found Behavior",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Path Not Found Behavior",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.standard.EvaluateJsonPath",
+        "yieldDuration" : "1 sec"
+      } ],
+      "remoteProcessGroups" : [ ],
+      "scheduledState" : "ENABLED",
+      "statelessFlowTimeout" : "1 min"
+    }, {
+      "comments" : "Starts or stops the replication of tables, and performs the initial snapshot load of data from newly added tables.",
+      "componentType" : "PROCESS_GROUP",
+      "connections" : [ {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Removes tables from the connector's list of replicating tables.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432b-0194-1000-4900-bd76afc47222",
+          "name" : "Remove Table From Replication",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "36f62d2a-f17c-32fa-bd11-66134e18659f",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "stale" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "67257b26-ba85-3cdf-902f-d3e1cb3cb9c7",
+          "name" : "PickTablesForReplication",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 1
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ {
+          "x" : 189.0,
+          "y" : 7.0
+        }, {
+          "x" : 189.0,
+          "y" : 57.0
+        } ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Registers tables that have been newly added to replication, and transfers them to begin replication.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432c-0194-1000-3f01-2a5546ed4dec",
+          "name" : "Register New Tables for Replication",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "9518434b-0194-1000-3fe9-3d915e26388f",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "comms failure" ],
+        "source" : {
+          "comments" : "Registers tables that have been newly added to replication, and transfers them to begin replication.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432c-0194-1000-3f01-2a5546ed4dec",
+          "name" : "Register New Tables for Replication",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+          "id" : "95184339-0194-1000-fb3e-8418fdcc4d5a",
+          "name" : "Input",
+          "type" : "INPUT_PORT"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "9518434c-0194-1000-bfd4-81146d9cad3e",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "new tables",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "Registers tables that have been newly added to replication, and transfers them to begin replication.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432c-0194-1000-3f01-2a5546ed4dec",
+          "name" : "Register New Tables for Replication",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ {
+          "x" : 924.3372192382812,
+          "y" : 13.662708282470703
+        }, {
+          "x" : 924.3372192382812,
+          "y" : 63.6627082824707
+        } ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Removes tables from the connector's list of replicating tables.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432b-0194-1000-4900-bd76afc47222",
+          "name" : "Remove Table From Replication",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "9518434f-0194-1000-ad0d-6328915dc953",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "comms failure" ],
+        "source" : {
+          "comments" : "Removes tables from the connector's list of replicating tables.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432b-0194-1000-4900-bd76afc47222",
+          "name" : "Remove Table From Replication",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Queries the source database for a list of accessible tables, and selects the ones configured for replication.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432e-0194-1000-88b4-70f1cb090a2c",
+          "name" : "Verify Configured Tables",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "95184350-0194-1000-6884-6ab2d1d59ea4",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "table patterns",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "Defines the tables or table patterns that should be included in replication.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432d-0194-1000-f6ca-34408c835ea6",
+          "name" : "Set Tables for Replication",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "67257b26-ba85-3cdf-902f-d3e1cb3cb9c7",
+          "name" : "PickTablesForReplication",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "993775d9-e26d-39ef-8807-4005698f95a0",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "matched" ],
+        "source" : {
+          "comments" : "Queries the source database for a list of accessible tables, and selects the ones configured for replication.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432e-0194-1000-88b4-70f1cb090a2c",
+          "name" : "Verify Configured Tables",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 3
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Registers tables that have been newly added to replication, and transfers them to begin replication.",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "9518432c-0194-1000-3f01-2a5546ed4dec",
+          "name" : "Register New Tables for Replication",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "ae8ac49a-8e03-3631-a3a9-1646c45204c2",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "new" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "67257b26-ba85-3cdf-902f-d3e1cb3cb9c7",
+          "name" : "PickTablesForReplication",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ {
+          "x" : 189.0,
+          "y" : -209.0
+        }, {
+          "x" : 189.0,
+          "y" : -159.0
+        } ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "67257b26-ba85-3cdf-902f-d3e1cb3cb9c7",
+          "name" : "PickTablesForReplication",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "baa93356-c1be-3ebe-8d77-77f144e103d8",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "failure" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "9518432a-0194-1000-2796-5585af3c3bd5",
+          "id" : "67257b26-ba85-3cdf-902f-d3e1cb3cb9c7",
+          "name" : "PickTablesForReplication",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      } ],
+      "controllerServices" : [ ],
+      "defaultBackPressureDataSizeThreshold" : "1 GB",
+      "defaultBackPressureObjectThreshold" : 10000,
+      "defaultFlowFileExpiration" : "0 sec",
+      "executionEngine" : "INHERITED",
+      "flowFileConcurrency" : "UNBOUNDED",
+      "flowFileOutboundPolicy" : "STREAM_WHEN_AVAILABLE",
+      "funnels" : [ ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+      "inputPorts" : [ ],
+      "labels" : [ ],
+      "maxConcurrentTasks" : 1,
+      "name" : "Snapshot Load",
+      "outputPorts" : [ ],
+      "parameterContextName" : "SQLServer Ingestion Parameters (2)",
+      "position" : {
+        "x" : -1208.0,
+        "y" : -24.0
+      },
+      "processGroups" : [ {
+        "comments" : "Runs the actual snapshot load for every newly-added table.",
+        "componentType" : "PROCESS_GROUP",
+        "connections" : [ {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : 229.97794342041016,
+            "y" : -280.6397705078125
+          }, {
+            "x" : 229.97794342041016,
+            "y" : -228.6397705078125
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "fc7d64e0-99ae-3cd0-8f5c-9e690d668569",
+            "name" : "Add Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "15b70965-1ac7-31fd-bfa4-f72538bb264b",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "fc7d64e0-99ae-3cd0-8f5c-9e690d668569",
+            "name" : "Add Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "fc7d64e0-99ae-3cd0-8f5c-9e690d668569",
+            "name" : "Add Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "3b3e7cb9-2e89-32a6-95e8-1fbd99e2e472",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "valid schema",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "matched" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "67b1dec2-dfaa-3127-b822-17d87f9bc32f",
+            "name" : "Check If Primary Key Is Present",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Creates the schema for the source table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184336-0194-1000-79d6-a4da6f61b64d",
+            "name" : "Create Snowflake Schema",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "569681e4-88b0-350c-b9bd-32a4b6ca7719",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "fc7d64e0-99ae-3cd0-8f5c-9e690d668569",
+            "name" : "Add Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : -608.0,
+            "y" : -680.0
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "9518433a-0194-1000-f9d3-71f902a0bdeb",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "table not found" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184330-0194-1000-a481-3998d93d5fff",
+            "name" : "Fetch Source Table Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : 226.97794342041016,
+            "y" : -60.6397705078125
+          }, {
+            "x" : 226.97794342041016,
+            "y" : -10.6397705078125
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Creates the schema for the source table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184336-0194-1000-79d6-a4da6f61b64d",
+            "name" : "Create Snowflake Schema",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "9518433b-0194-1000-ba3d-dc852c3d973e",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "Creates the schema for the source table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184336-0194-1000-79d6-a4da6f61b64d",
+            "name" : "Create Snowflake Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Remove metadata columns before the table schema is used to fetch snapshot data.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "589e424f-754a-3a11-bb27-9433ff93b7a4",
+            "name" : "Remove Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "9518433c-0194-1000-6ebf-b88263870ed7",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "Wait until the replication state of the table indicates that the connector started collecting incremental changes for it. This ensures consistent replication of all changes to the source data made while the snapshot load is running.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184335-0194-1000-0608-860e8929c48d",
+            "name" : "Wait for Incremental Load to Begin",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : -608.0,
+            "y" : 392.0
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "9518433d-0194-1000-a2b1-84fda621315c",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "Wait until the replication state of the table indicates that the connector started collecting incremental changes for it. This ensures consistent replication of all changes to the source data made while the snapshot load is running.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184335-0194-1000-0608-860e8929c48d",
+            "name" : "Wait for Incremental Load to Begin",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184330-0194-1000-a481-3998d93d5fff",
+            "name" : "Fetch Source Table Schema",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "9518433e-0194-1000-6269-fb0f4fa917ba",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "" ],
+          "source" : {
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184339-0194-1000-fb3e-8418fdcc4d5a",
+            "name" : "Input",
+            "type" : "INPUT_PORT"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : 226.97794342041016,
+            "y" : 148.6397705078125
+          }, {
+            "x" : 226.97794342041016,
+            "y" : 198.6397705078125
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Creates the destination table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184332-0194-1000-325b-d685256e5dcd",
+            "name" : "Create Snowflake Table",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "9518433f-0194-1000-1822-788849215345",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "Creates the destination table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184332-0194-1000-325b-d685256e5dcd",
+            "name" : "Create Snowflake Table",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Wait until the replication state of the table indicates that the connector started collecting incremental changes for it. This ensures consistent replication of all changes to the source data made while the snapshot load is running.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184335-0194-1000-0608-860e8929c48d",
+            "name" : "Wait for Incremental Load to Begin",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184340-0194-1000-7502-1a8a79b2df6c",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "Creates the destination table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184332-0194-1000-325b-d685256e5dcd",
+            "name" : "Create Snowflake Table",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : -608.0,
+            "y" : 1254.0
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184341-0194-1000-d2d6-b40b7e56be86",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184331-0194-1000-2da9-944adcd3244b",
+            "name" : "Upload Rows via Snowpipe Streaming",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "10 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184331-0194-1000-2da9-944adcd3244b",
+            "name" : "Upload Rows via Snowpipe Streaming",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184342-0194-1000-12d0-1f4ca1ce7c2e",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "Adds additional metadata columns to the source schema.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "1b556196-ee83-3755-8179-99c267e3d31f",
+            "name" : "Add Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Update the replication state of the table to indicate that its snapshot load is complete.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184333-0194-1000-3e65-366e18c11dd2",
+            "name" : "Mark Snapshot Complete",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184343-0194-1000-50b9-b6c61b7a2ddc",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "snapshot complete" ],
+          "source" : {
+            "comments" : "Verifies that all FlowFiles with source table rows were processed and replicated.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184338-0194-1000-659a-a25f20d39a2f",
+            "name" : "Check if All Rows Stored",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : -608.0,
+            "y" : 832.0
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184344-0194-1000-0a2e-40496ca36379",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "failure", "retryable failure" ],
+          "source" : {
+            "comments" : "Retrieve the initial snapshot of data from the source table.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184337-0194-1000-9e3c-c0a6cf53acf1",
+            "name" : "Fetch Table Rows",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : -909.7503051757812,
+            "y" : 1455.00830078125
+          }, {
+            "x" : -909.7503051757812,
+            "y" : 1511.00830078125
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184345-0194-1000-c308-7962be359b2b",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "comms failure" ],
+          "source" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Creates the destination table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184332-0194-1000-325b-d685256e5dcd",
+            "name" : "Create Snowflake Table",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184346-0194-1000-d79e-debf8cf368c3",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "Creates the schema for the source table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184336-0194-1000-79d6-a4da6f61b64d",
+            "name" : "Create Snowflake Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "67b1dec2-dfaa-3127-b822-17d87f9bc32f",
+            "name" : "Check If Primary Key Is Present",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184347-0194-1000-0c86-1eb2b9275918",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184330-0194-1000-a481-3998d93d5fff",
+            "name" : "Fetch Source Table Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : 227.0,
+            "y" : 1684.5
+          }, {
+            "x" : 227.0,
+            "y" : 1734.5
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Update the replication state of the table to indicate that its snapshot load is complete.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184333-0194-1000-3e65-366e18c11dd2",
+            "name" : "Mark Snapshot Complete",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184348-0194-1000-96d6-235f7eba13d0",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "comms failure" ],
+          "source" : {
+            "comments" : "Update the replication state of the table to indicate that its snapshot load is complete.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184333-0194-1000-3e65-366e18c11dd2",
+            "name" : "Mark Snapshot Complete",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : 227.97794342041016,
+            "y" : -707.6397705078125
+          }, {
+            "x" : 227.97794342041016,
+            "y" : -657.6397705078125
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184330-0194-1000-a481-3998d93d5fff",
+            "name" : "Fetch Source Table Schema",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184349-0194-1000-ac7f-ec7949a7fd18",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184330-0194-1000-a481-3998d93d5fff",
+            "name" : "Fetch Source Table Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Verifies that all FlowFiles with source table rows were processed and replicated.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184338-0194-1000-659a-a25f20d39a2f",
+            "name" : "Check if All Rows Stored",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "9518434a-0194-1000-5751-a998624689cb",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184331-0194-1000-2da9-944adcd3244b",
+            "name" : "Upload Rows via Snowpipe Streaming",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : -608.0,
+            "y" : 1040.0
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "a303bcb3-ff54-355d-9ed1-d4734b6cb2d3",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "Adds additional metadata columns to the source schema.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "1b556196-ee83-3755-8179-99c267e3d31f",
+            "name" : "Add Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "10 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Adds additional metadata columns to the source schema.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "1b556196-ee83-3755-8179-99c267e3d31f",
+            "name" : "Add Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "ab252e42-d35a-3c2b-916c-f5a89b2a1dc6",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "rows" ],
+          "source" : {
+            "comments" : "Retrieve the initial snapshot of data from the source table.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184337-0194-1000-9e3c-c0a6cf53acf1",
+            "name" : "Fetch Table Rows",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : 231.5424574380586,
+            "y" : 589.3295648309129
+          }, {
+            "x" : 231.5424574380586,
+            "y" : 642.3295648309129
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Remove metadata columns before the table schema is used to fetch snapshot data.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "589e424f-754a-3a11-bb27-9433ff93b7a4",
+            "name" : "Remove Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "b0ef6896-da08-39a5-868f-534e1ef674c9",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "Remove metadata columns before the table schema is used to fetch snapshot data.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "589e424f-754a-3a11-bb27-9433ff93b7a4",
+            "name" : "Remove Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Retrieve the initial snapshot of data from the source table.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184337-0194-1000-9e3c-c0a6cf53acf1",
+            "name" : "Fetch Table Rows",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "d9010a82-1d8a-35b1-94da-f3cfc13f7a26",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "Remove metadata columns before the table schema is used to fetch snapshot data.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "589e424f-754a-3a11-bb27-9433ff93b7a4",
+            "name" : "Remove Snowflake Specific Columns",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Put an entry in the logs marking the completion of the snapshot load.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "78b7c6ee-f4bc-3670-bd5e-b700c010cca9",
+            "name" : "Log Snapshot Complete Message",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "ef6a80b9-02ee-37c6-bfb8-44161d7d97d6",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "Update the replication state of the table to indicate that its snapshot load is complete.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184333-0194-1000-3e65-366e18c11dd2",
+            "name" : "Mark Snapshot Complete",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : -608.0,
+            "y" : -480.0
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "f6e6fc7f-aa8b-3c0d-8ba5-e494b305048d",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "primary key missing",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "unmatched" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "67b1dec2-dfaa-3127-b822-17d87f9bc32f",
+            "name" : "Check If Primary Key Is Present",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 10000,
+          "bends" : [ {
+            "x" : -608.0,
+            "y" : 176.0
+          } ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184334-0194-1000-317e-80fa71be85be",
+            "name" : "Mark Table Replication Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "fb45c682-5f75-3e2a-a7e9-6d30f55bf5db",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "table exists",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ ],
+          "selectedRelationships" : [ "object exists" ],
+          "source" : {
+            "comments" : "Creates the destination table in Snowflake.",
+            "groupId" : "9518432f-0194-1000-5322-994c5b575b71",
+            "id" : "95184332-0194-1000-325b-d685256e5dcd",
+            "name" : "Create Snowflake Table",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        } ],
+        "controllerServices" : [ {
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "nifi-record-serialization-services-nar",
+            "group" : "org.apache.nifi",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "",
+          "componentType" : "CONTROLLER_SERVICE",
+          "controllerServiceApis" : [ {
+            "bundle" : {
+              "artifact" : "nifi-standard-services-api-nar",
+              "group" : "org.apache.nifi",
+              "version" : "2025.7.24.18"
+            },
+            "type" : "org.apache.nifi.serialization.RecordReaderFactory"
+          } ],
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "3f6a59ce-7f6d-3b1a-a0cc-441ba65b0710",
+          "name" : "Read JSON, Infer Schema",
+          "properties" : {
+            "Max String Length" : "20 MB",
+            "schema-application-strategy" : "SELECTED_PART",
+            "schema-name" : "${schema.name}",
+            "starting-field-strategy" : "ROOT_NODE",
+            "schema-access-strategy" : "infer-schema",
+            "schema-text" : "${avro.schema}",
+            "Allow Comments" : "false"
+          },
+          "propertyDescriptors" : {
+            "schema-reference-reader" : {
+              "displayName" : "Schema Reference Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "schema-reference-reader",
+              "sensitive" : false
+            },
+            "schema-branch" : {
+              "displayName" : "Schema Branch",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "schema-branch",
+              "sensitive" : false
+            },
+            "Max String Length" : {
+              "displayName" : "Max String Length",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Max String Length",
+              "sensitive" : false
+            },
+            "schema-application-strategy" : {
+              "displayName" : "Schema Application Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "schema-application-strategy",
+              "sensitive" : false
+            },
+            "Timestamp Format" : {
+              "displayName" : "Timestamp Format",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Timestamp Format",
+              "sensitive" : false
+            },
+            "schema-inference-cache" : {
+              "displayName" : "Schema Inference Cache",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "schema-inference-cache",
+              "sensitive" : false
+            },
+            "Date Format" : {
+              "displayName" : "Date Format",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Date Format",
+              "sensitive" : false
+            },
+            "schema-name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "schema-name",
+              "sensitive" : false
+            },
+            "starting-field-strategy" : {
+              "displayName" : "Starting Field Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "starting-field-strategy",
+              "sensitive" : false
+            },
+            "schema-registry" : {
+              "displayName" : "Schema Registry",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "schema-registry",
+              "sensitive" : false
+            },
+            "starting-field-name" : {
+              "displayName" : "Starting Field Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "starting-field-name",
+              "sensitive" : false
+            },
+            "Time Format" : {
+              "displayName" : "Time Format",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Time Format",
+              "sensitive" : false
+            },
+            "schema-access-strategy" : {
+              "displayName" : "Schema Access Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "schema-access-strategy",
+              "sensitive" : false
+            },
+            "schema-version" : {
+              "displayName" : "Schema Version",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "schema-version",
+              "sensitive" : false
+            },
+            "schema-text" : {
+              "displayName" : "Schema Text",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "schema-text",
+              "sensitive" : false
+            },
+            "Allow Comments" : {
+              "displayName" : "Allow Comments",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Allow Comments",
+              "sensitive" : false
+            }
+          },
+          "scheduledState" : "DISABLED",
+          "type" : "org.apache.nifi.json.JsonTreeReader"
+        } ],
+        "defaultBackPressureDataSizeThreshold" : "1 GB",
+        "defaultBackPressureObjectThreshold" : 10000,
+        "defaultFlowFileExpiration" : "0 sec",
+        "executionEngine" : "INHERITED",
+        "flowFileConcurrency" : "UNBOUNDED",
+        "flowFileOutboundPolicy" : "STREAM_WHEN_AVAILABLE",
+        "funnels" : [ ],
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "9518432f-0194-1000-5322-994c5b575b71",
+        "inputPorts" : [ {
+          "allowRemoteAccess" : false,
+          "componentType" : "INPUT_PORT",
+          "concurrentlySchedulableTaskCount" : 1,
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184339-0194-1000-fb3e-8418fdcc4d5a",
+          "name" : "Input",
+          "portFunction" : "STANDARD",
+          "position" : {
+            "x" : -184.0,
+            "y" : -888.0
+          },
+          "scheduledState" : "ENABLED",
+          "type" : "INPUT_PORT"
+        } ],
+        "labels" : [ ],
+        "maxConcurrentTasks" : 1,
+        "name" : "Perform Snapshot Load",
+        "outputPorts" : [ ],
+        "parameterContextName" : "SQLServer Ingestion Parameters (2)",
+        "position" : {
+          "x" : -296.0,
+          "y" : 200.0
+        },
+        "processGroups" : [ ],
+        "processors" : [ {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "nifi-standard-nar",
+            "group" : "org.apache.nifi",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Adds additional metadata columns to the source schema.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "1b556196-ee83-3755-8179-99c267e3d31f",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Add Snowflake Specific Columns",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 976.0
+          },
+          "properties" : {
+            "Record Writer" : "50c96126-f1cd-3111-9aad-4b47b2856551",
+            "Record Reader" : "24cdd13f-c206-3d50-bfc2-d29011a189ca",
+            "/_SNOWFLAKE_UPDATED_AT" : "${now():format(\"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'\")}",
+            "/_SNOWFLAKE_DELETED" : "${literal(false)}",
+            "/_SNOWFLAKE_INSERTED_AT" : "${now():format(\"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'\")}",
+            "Replacement Value Strategy" : "literal-value"
+          },
+          "propertyDescriptors" : {
+            "Record Writer" : {
+              "displayName" : "Record Writer",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Writer",
+              "sensitive" : false
+            },
+            "Record Reader" : {
+              "displayName" : "Record Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Reader",
+              "sensitive" : false
+            },
+            "/_SNOWFLAKE_UPDATED_AT" : {
+              "displayName" : "/_SNOWFLAKE_UPDATED_AT",
+              "dynamic" : true,
+              "identifiesControllerService" : false,
+              "name" : "/_SNOWFLAKE_UPDATED_AT",
+              "sensitive" : false
+            },
+            "/_SNOWFLAKE_DELETED" : {
+              "displayName" : "/_SNOWFLAKE_DELETED",
+              "dynamic" : true,
+              "identifiesControllerService" : false,
+              "name" : "/_SNOWFLAKE_DELETED",
+              "sensitive" : false
+            },
+            "/_SNOWFLAKE_INSERTED_AT" : {
+              "displayName" : "/_SNOWFLAKE_INSERTED_AT",
+              "dynamic" : true,
+              "identifiesControllerService" : false,
+              "name" : "/_SNOWFLAKE_INSERTED_AT",
+              "sensitive" : false
+            },
+            "Replacement Value Strategy" : {
+              "displayName" : "Replacement Value Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Replacement Value Strategy",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "org.apache.nifi.processors.standard.UpdateRecord",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "nifi-standard-nar",
+            "group" : "org.apache.nifi",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Remove metadata columns before the table schema is used to fetch snapshot data.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "589e424f-754a-3a11-bb27-9433ff93b7a4",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Remove Snowflake Specific Columns",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 552.0
+          },
+          "properties" : {
+            "Record Writer" : "50c96126-f1cd-3111-9aad-4b47b2856551",
+            "Record Reader" : "3f6a59ce-7f6d-3b1a-a0cc-441ba65b0710",
+            "/columns" : "arrayOf( /columns[0..-4] )",
+            "Replacement Value Strategy" : "record-path-value"
+          },
+          "propertyDescriptors" : {
+            "Record Writer" : {
+              "displayName" : "Record Writer",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Writer",
+              "sensitive" : false
+            },
+            "Record Reader" : {
+              "displayName" : "Record Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Reader",
+              "sensitive" : false
+            },
+            "/columns" : {
+              "displayName" : "/columns",
+              "dynamic" : true,
+              "identifiesControllerService" : false,
+              "name" : "/columns",
+              "sensitive" : false
+            },
+            "Replacement Value Strategy" : {
+              "displayName" : "Replacement Value Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Replacement Value Strategy",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "org.apache.nifi.processors.standard.UpdateRecord",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "nifi-standard-nar",
+            "group" : "org.apache.nifi",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "67b1dec2-dfaa-3127-b822-17d87f9bc32f",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Check If Primary Key Is Present",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : -544.0
+          },
+          "properties" : {
+            "primaryKeyIsPresent" : "${primary.key.count:equals(0):not()}",
+            "Routing Strategy" : "Route to 'match' if all match"
+          },
+          "propertyDescriptors" : {
+            "primaryKeyIsPresent" : {
+              "displayName" : "primaryKeyIsPresent",
+              "dynamic" : true,
+              "identifiesControllerService" : false,
+              "name" : "primaryKeyIsPresent",
+              "sensitive" : false
+            },
+            "Routing Strategy" : {
+              "displayName" : "Routing Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Routing Strategy",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "org.apache.nifi.processors.standard.RouteOnAttribute",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ "success" ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "nifi-standard-nar",
+            "group" : "org.apache.nifi",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Put an entry in the logs marking the completion of the snapshot load.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "78b7c6ee-f4bc-3670-bd5e-b700c010cca9",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Log Snapshot Complete Message",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 1856.0
+          },
+          "properties" : {
+            "log-message" : "Completed snapshot of ${source.schema.name}.${source.table.name} consisting of ${start.row.index:plus( ${rows.fetched} )} rows in ${now():minus( ${lineageStartDate} ):divide(1000)} seconds",
+            "log-level" : "info"
+          },
+          "propertyDescriptors" : {
+            "log-message" : {
+              "displayName" : "Log message",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "log-message",
+              "sensitive" : false
+            },
+            "log-level" : {
+              "displayName" : "Log Level",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "log-level",
+              "sensitive" : false
+            },
+            "log-prefix" : {
+              "displayName" : "Log prefix",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "log-prefix",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "org.apache.nifi.processors.standard.LogMessage",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-database-cdc-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184330-0194-1000-a481-3998d93d5fff",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Fetch Source Table Schema",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : -744.0
+          },
+          "properties" : {
+            "Table Name" : "${source.table.name}",
+            "Connection Pool" : "a7df0df5-64ea-391c-9990-5b089d4eea95",
+            "Column Filter Service" : "1d805b66-4a8a-3fb2-a7c9-0876eb122423",
+            "Schema Name" : "${source.schema.name}"
+          },
+          "propertyDescriptors" : {
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "Connection Pool" : {
+              "displayName" : "Connection Pool",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Connection Pool",
+              "sensitive" : false
+            },
+            "Column Filter Service" : {
+              "displayName" : "Column Filter Service",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Column Filter Service",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.database.FetchSourceTableSchema",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "YIELD_PROCESSOR",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-snowpipe-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 2,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184331-0194-1000-2da9-944adcd3244b",
+          "maxBackoffPeriod" : "30 sec",
+          "name" : "Upload Rows via Snowpipe Streaming",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 1200.0
+          },
+          "properties" : {
+            "Account" : "#{Snowflake Account Identifier}",
+            "User" : "#{Snowflake Username}",
+            "Table" : "\"${source.table.name}\"",
+            "Max Batch Size" : "10000",
+            "Schema" : "\"${source.schema.name}\"",
+            "Max Tasks Per Group" : "1",
+            "Record Offset" : "${start.row.index}",
+            "Record Reader" : "3f6a59ce-7f6d-3b1a-a0cc-441ba65b0710",
+            "Iceberg Enabled" : "false",
+            "Snowpipe Channel Index" : "1",
+            "Private Key Service" : "a9d0fce7-8560-33f6-8ed0-992949862808",
+            "Connection Strategy" : "STANDARD",
+            "Role" : "#{Snowflake Role}",
+            "Record Offset Strategy" : "Use Expression Language",
+            "Snowpipe Channel Prefix" : "${hostname(false)}.4",
+            "Client Lag" : "1 sec",
+            "Authentication Strategy" : "#{Snowflake Authentication Strategy}",
+            "Delivery Guarantee" : "Exactly once",
+            "Database" : "DATA_NPI"
+          },
+          "propertyDescriptors" : {
+            "Account" : {
+              "displayName" : "Account",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Account",
+              "sensitive" : false
+            },
+            "User" : {
+              "displayName" : "User",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "User",
+              "sensitive" : false
+            },
+            "Table" : {
+              "displayName" : "Table",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table",
+              "sensitive" : false
+            },
+            "Concurrency Group" : {
+              "displayName" : "Concurrency Group",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Concurrency Group",
+              "sensitive" : false
+            },
+            "Max Batch Size" : {
+              "displayName" : "Max Batch Size",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Max Batch Size",
+              "sensitive" : false
+            },
+            "Schema" : {
+              "displayName" : "Schema",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema",
+              "sensitive" : false
+            },
+            "Max Tasks Per Group" : {
+              "displayName" : "Max Tasks Per Group",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Max Tasks Per Group",
+              "sensitive" : false
+            },
+            "Record Offset" : {
+              "displayName" : "Record Offset",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Record Offset",
+              "sensitive" : false
+            },
+            "Record Reader" : {
+              "displayName" : "Record Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Reader",
+              "sensitive" : false
+            },
+            "Iceberg Enabled" : {
+              "displayName" : "Iceberg Enabled",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Iceberg Enabled",
+              "sensitive" : false
+            },
+            "Snowpipe Channel Index" : {
+              "displayName" : "Snowpipe Channel Index",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Snowpipe Channel Index",
+              "sensitive" : false
+            },
+            "Private Key Service" : {
+              "displayName" : "Private Key Service",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Private Key Service",
+              "sensitive" : false
+            },
+            "Connection Strategy" : {
+              "displayName" : "Connection Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Connection Strategy",
+              "sensitive" : false
+            },
+            "Role" : {
+              "displayName" : "Role",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Role",
+              "sensitive" : false
+            },
+            "Record Offset Strategy" : {
+              "displayName" : "Record Offset Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Record Offset Strategy",
+              "sensitive" : false
+            },
+            "Snowpipe Channel Prefix" : {
+              "displayName" : "Snowpipe Channel Prefix",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Snowpipe Channel Prefix",
+              "sensitive" : false
+            },
+            "Client Lag" : {
+              "displayName" : "Client Lag",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Client Lag",
+              "sensitive" : false
+            },
+            "Authentication Strategy" : {
+              "displayName" : "Authentication Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Authentication Strategy",
+              "sensitive" : false
+            },
+            "Delivery Guarantee" : {
+              "displayName" : "Delivery Guarantee",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Delivery Guarantee",
+              "sensitive" : false
+            },
+            "Record Offset Record Path" : {
+              "displayName" : "Record Offset Record Path",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Record Offset Record Path",
+              "sensitive" : false
+            },
+            "Database" : {
+              "displayName" : "Database",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Database",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ "failure" ],
+          "retryCount" : 10000000,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.snowpipe.PutSnowpipeStreaming",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-snowflake-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Creates the destination table in Snowflake.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184332-0194-1000-325b-d685256e5dcd",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Create Snowflake Table",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 112.0
+          },
+          "properties" : {
+            "Table Name" : "${source.table.name}",
+            "Table Metadata Cache Expiration Time" : "30 sec",
+            "Update Type" : "Create Table",
+            "Max Batch Size" : "1",
+            "Include Not Null Constraints" : "true",
+            "Table Schema Strategy" : "FlowFile Content",
+            "Schema Name" : "${source.schema.name}",
+            "Add Column Strategy" : "Alter Table",
+            "Use Table Metadata Cache" : "false",
+            "Alter Column Type Strategy" : "Fail",
+            "Column Removal Strategy" : "Drop Column",
+            "Drop Not Null Strategy" : "Alter Table",
+            "Add Not Null Strategy" : "Alter Table",
+            "Create Stream" : "false",
+            "Modify Primary Key Strategy" : "Alter Table",
+            "Drop Column Strategy" : "Alter Table",
+            "Connection Pool" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+            "Include Primary Key Constraints" : "false"
+          },
+          "propertyDescriptors" : {
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "Table Metadata Cache Expiration Time" : {
+              "displayName" : "Table Metadata Cache Expiration Time",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Metadata Cache Expiration Time",
+              "sensitive" : false
+            },
+            "Update Type" : {
+              "displayName" : "Update Type",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Update Type",
+              "sensitive" : false
+            },
+            "Max Batch Size" : {
+              "displayName" : "Max Batch Size",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Max Batch Size",
+              "sensitive" : false
+            },
+            "Include Not Null Constraints" : {
+              "displayName" : "Include Not Null Constraints",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Include Not Null Constraints",
+              "sensitive" : false
+            },
+            "Stream Creation Parameters" : {
+              "displayName" : "Stream Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Stream Creation Parameters",
+              "sensitive" : false
+            },
+            "Removed Column Name Suffix" : {
+              "displayName" : "Removed Column Name Suffix",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Removed Column Name Suffix",
+              "sensitive" : false
+            },
+            "Table Stream Creation Parameters" : {
+              "displayName" : "Table Stream Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Stream Creation Parameters",
+              "sensitive" : false
+            },
+            "Stream Name" : {
+              "displayName" : "Stream Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Stream Name",
+              "sensitive" : false
+            },
+            "Record Reader" : {
+              "displayName" : "Record Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Reader",
+              "sensitive" : false
+            },
+            "Desired Schema" : {
+              "displayName" : "Desired Schema",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Desired Schema",
+              "sensitive" : false
+            },
+            "Table Schema Strategy" : {
+              "displayName" : "Table Schema Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Schema Strategy",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            },
+            "Add Column Strategy" : {
+              "displayName" : "Add Column Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Add Column Strategy",
+              "sensitive" : false
+            },
+            "Table Stream Name" : {
+              "displayName" : "Table Stream Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Stream Name",
+              "sensitive" : false
+            },
+            "Use Table Metadata Cache" : {
+              "displayName" : "Use Table Metadata Cache",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Use Table Metadata Cache",
+              "sensitive" : false
+            },
+            "Alter Column Type Strategy" : {
+              "displayName" : "Alter Column Type Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Alter Column Type Strategy",
+              "sensitive" : false
+            },
+            "Column Removal Strategy" : {
+              "displayName" : "Column Removal Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Column Removal Strategy",
+              "sensitive" : false
+            },
+            "Column Name Transformation" : {
+              "displayName" : "Column Name Transformation",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Column Name Transformation",
+              "sensitive" : false
+            },
+            "Drop Not Null Strategy" : {
+              "displayName" : "Drop Not Null Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Drop Not Null Strategy",
+              "sensitive" : false
+            },
+            "Add Not Null Strategy" : {
+              "displayName" : "Add Not Null Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Add Not Null Strategy",
+              "sensitive" : false
+            },
+            "Creation Parameters" : {
+              "displayName" : "Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Creation Parameters",
+              "sensitive" : false
+            },
+            "Create Stream" : {
+              "displayName" : "Create Stream",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Create Stream",
+              "sensitive" : false
+            },
+            "Modify Primary Key Strategy" : {
+              "displayName" : "Modify Primary Key Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Modify Primary Key Strategy",
+              "sensitive" : false
+            },
+            "Drop Column Strategy" : {
+              "displayName" : "Drop Column Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Drop Column Strategy",
+              "sensitive" : false
+            },
+            "Connection Pool" : {
+              "displayName" : "Connection Pool",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Connection Pool",
+              "sensitive" : false
+            },
+            "Include Primary Key Constraints" : {
+              "displayName" : "Include Primary Key Constraints",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Include Primary Key Constraints",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.snowflake.UpdateSnowflakeDatabase",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ "state exists" ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-database-cdc-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Update the replication state of the table to indicate that its snapshot load is complete.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184333-0194-1000-3e65-366e18c11dd2",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Mark Snapshot Complete",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 1648.0
+          },
+          "properties" : {
+            "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+            "Table Name" : "${source.table.name}",
+            "CDC Schema Registry" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+            "Desired State" : "Incremental Replication",
+            "Overwrite Existing" : "true",
+            "Schema Name" : "${source.schema.name}"
+          },
+          "propertyDescriptors" : {
+            "Table State Service" : {
+              "displayName" : "Table State Service",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Table State Service",
+              "sensitive" : false
+            },
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "CDC Schema Registry" : {
+              "displayName" : "CDC Schema Registry",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "CDC Schema Registry",
+              "sensitive" : false
+            },
+            "Desired State" : {
+              "displayName" : "Desired State",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Desired State",
+              "sensitive" : false
+            },
+            "Overwrite Existing" : {
+              "displayName" : "Overwrite Existing",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Overwrite Existing",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.database.UpdateTableState",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ "state exists", "success" ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-database-cdc-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Updates the state of the table to permanently failed because an error occurred that the connector cannot automatically recover from.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184334-0194-1000-317e-80fa71be85be",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Mark Table Replication Failed",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -784.0,
+            "y" : 1432.0
+          },
+          "properties" : {
+            "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+            "Table Name" : "${source.table.name}",
+            "CDC Schema Registry" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+            "Desired State" : "Failed",
+            "Overwrite Existing" : "true",
+            "Schema Name" : "${source.schema.name}"
+          },
+          "propertyDescriptors" : {
+            "Table State Service" : {
+              "displayName" : "Table State Service",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Table State Service",
+              "sensitive" : false
+            },
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "CDC Schema Registry" : {
+              "displayName" : "CDC Schema Registry",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "CDC Schema Registry",
+              "sensitive" : false
+            },
+            "Desired State" : {
+              "displayName" : "Desired State",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Desired State",
+              "sensitive" : false
+            },
+            "Overwrite Existing" : {
+              "displayName" : "Overwrite Existing",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Overwrite Existing",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.database.UpdateTableState",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-database-cdc-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Wait until the replication state of the table indicates that the connector started collecting incremental changes for it. This ensures consistent replication of all changes to the source data made while the snapshot load is running.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184335-0194-1000-0608-860e8929c48d",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Wait for Incremental Load to Begin",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 328.0
+          },
+          "properties" : {
+            "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+            "Accepted State" : "SNAPSHOT_REPLICATION"
+          },
+          "propertyDescriptors" : {
+            "Table State Service" : {
+              "displayName" : "Table State Service",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Table State Service",
+              "sensitive" : false
+            },
+            "Accepted State" : {
+              "displayName" : "Accepted State",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Accepted State",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.database.WaitForTableState",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-snowflake-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Creates the schema for the source table in Snowflake.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184336-0194-1000-79d6-a4da6f61b64d",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Create Snowflake Schema",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : -96.0
+          },
+          "properties" : {
+            "Table Metadata Cache Expiration Time" : "30 sec",
+            "Update Type" : "Create Schema If Not Exists",
+            "Max Batch Size" : "1",
+            "Include Not Null Constraints" : "true",
+            "Table Schema Strategy" : "FlowFile Content",
+            "Schema Name" : "${source.schema.name}",
+            "Add Column Strategy" : "Alter Table",
+            "Use Table Metadata Cache" : "false",
+            "Alter Column Type Strategy" : "Fail",
+            "Column Removal Strategy" : "Drop Column",
+            "Drop Not Null Strategy" : "Alter Table",
+            "Add Not Null Strategy" : "Alter Table",
+            "Create Stream" : "false",
+            "Modify Primary Key Strategy" : "Alter Table",
+            "Drop Column Strategy" : "Alter Table",
+            "Connection Pool" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+            "Include Primary Key Constraints" : "true"
+          },
+          "propertyDescriptors" : {
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "Table Metadata Cache Expiration Time" : {
+              "displayName" : "Table Metadata Cache Expiration Time",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Metadata Cache Expiration Time",
+              "sensitive" : false
+            },
+            "Update Type" : {
+              "displayName" : "Update Type",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Update Type",
+              "sensitive" : false
+            },
+            "Max Batch Size" : {
+              "displayName" : "Max Batch Size",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Max Batch Size",
+              "sensitive" : false
+            },
+            "Include Not Null Constraints" : {
+              "displayName" : "Include Not Null Constraints",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Include Not Null Constraints",
+              "sensitive" : false
+            },
+            "Stream Creation Parameters" : {
+              "displayName" : "Stream Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Stream Creation Parameters",
+              "sensitive" : false
+            },
+            "Removed Column Name Suffix" : {
+              "displayName" : "Removed Column Name Suffix",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Removed Column Name Suffix",
+              "sensitive" : false
+            },
+            "Table Stream Creation Parameters" : {
+              "displayName" : "Table Stream Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Stream Creation Parameters",
+              "sensitive" : false
+            },
+            "Stream Name" : {
+              "displayName" : "Stream Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Stream Name",
+              "sensitive" : false
+            },
+            "Record Reader" : {
+              "displayName" : "Record Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Reader",
+              "sensitive" : false
+            },
+            "Desired Schema" : {
+              "displayName" : "Desired Schema",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Desired Schema",
+              "sensitive" : false
+            },
+            "Table Schema Strategy" : {
+              "displayName" : "Table Schema Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Schema Strategy",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            },
+            "Add Column Strategy" : {
+              "displayName" : "Add Column Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Add Column Strategy",
+              "sensitive" : false
+            },
+            "Table Stream Name" : {
+              "displayName" : "Table Stream Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Stream Name",
+              "sensitive" : false
+            },
+            "Use Table Metadata Cache" : {
+              "displayName" : "Use Table Metadata Cache",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Use Table Metadata Cache",
+              "sensitive" : false
+            },
+            "Alter Column Type Strategy" : {
+              "displayName" : "Alter Column Type Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Alter Column Type Strategy",
+              "sensitive" : false
+            },
+            "Column Removal Strategy" : {
+              "displayName" : "Column Removal Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Column Removal Strategy",
+              "sensitive" : false
+            },
+            "Column Name Transformation" : {
+              "displayName" : "Column Name Transformation",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Column Name Transformation",
+              "sensitive" : false
+            },
+            "Drop Not Null Strategy" : {
+              "displayName" : "Drop Not Null Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Drop Not Null Strategy",
+              "sensitive" : false
+            },
+            "Add Not Null Strategy" : {
+              "displayName" : "Add Not Null Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Add Not Null Strategy",
+              "sensitive" : false
+            },
+            "Creation Parameters" : {
+              "displayName" : "Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Creation Parameters",
+              "sensitive" : false
+            },
+            "Create Stream" : {
+              "displayName" : "Create Stream",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Create Stream",
+              "sensitive" : false
+            },
+            "Modify Primary Key Strategy" : {
+              "displayName" : "Modify Primary Key Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Modify Primary Key Strategy",
+              "sensitive" : false
+            },
+            "Drop Column Strategy" : {
+              "displayName" : "Drop Column Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Drop Column Strategy",
+              "sensitive" : false
+            },
+            "Connection Pool" : {
+              "displayName" : "Connection Pool",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Connection Pool",
+              "sensitive" : false
+            },
+            "Include Primary Key Constraints" : {
+              "displayName" : "Include Primary Key Constraints",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Include Primary Key Constraints",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.snowflake.UpdateSnowflakeDatabase",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ "complete" ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-database-cdc-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Retrieve the initial snapshot of data from the source table.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184337-0194-1000-9e3c-c0a6cf53acf1",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Fetch Table Rows",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 768.0
+          },
+          "properties" : {
+            "JDBC Driver Location" : "#{SQLServer JDBC Driver}",
+            "Table Name" : "${source.table.name}",
+            "Max Batch Size" : "100000",
+            "Connection Pool" : "a7df0df5-64ea-391c-9990-5b089d4eea95",
+            "Record Writer" : "50c96126-f1cd-3111-9aad-4b47b2856551",
+            "Schema Name" : "${source.schema.name}",
+            "Fetch Size" : "100"
+          },
+          "propertyDescriptors" : {
+            "JDBC Driver Location" : {
+              "displayName" : "JDBC Driver Location",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "JDBC Driver Location",
+              "resourceDefinition" : {
+                "cardinality" : "MULTIPLE",
+                "resourceTypes" : [ "DIRECTORY", "FILE", "URL" ]
+              },
+              "sensitive" : false
+            },
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "Max Batch Size" : {
+              "displayName" : "Max Batch Size",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Max Batch Size",
+              "sensitive" : false
+            },
+            "Connection Pool" : {
+              "displayName" : "Connection Pool",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Connection Pool",
+              "sensitive" : false
+            },
+            "Record Writer" : {
+              "displayName" : "Record Writer",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Writer",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            },
+            "Fetch Size" : {
+              "displayName" : "Fetch Size",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Fetch Size",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ "retryable failure" ],
+          "retryCount" : 1000000,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.database.FetchTableSnapshot",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ "unmatched" ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "nifi-standard-nar",
+            "group" : "org.apache.nifi",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Verifies that all FlowFiles with source table rows were processed and replicated.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "95184338-0194-1000-659a-a25f20d39a2f",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Check if All Rows Stored",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : 1416.0
+          },
+          "properties" : {
+            "Routing Strategy" : "Route to Property name",
+            "snapshot complete" : "${snapshot.complete:equals('true')}"
+          },
+          "propertyDescriptors" : {
+            "Routing Strategy" : {
+              "displayName" : "Routing Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Routing Strategy",
+              "sensitive" : false
+            },
+            "snapshot complete" : {
+              "displayName" : "snapshot complete",
+              "dynamic" : true,
+              "identifiesControllerService" : false,
+              "name" : "snapshot complete",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "org.apache.nifi.processors.standard.RouteOnAttribute",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "nifi-standard-nar",
+            "group" : "org.apache.nifi",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "9518432f-0194-1000-5322-994c5b575b71",
+          "identifier" : "fc7d64e0-99ae-3cd0-8f5c-9e690d668569",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Add Snowflake Specific Columns",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : -240.0,
+            "y" : -312.0
+          },
+          "properties" : {
+            "Record Writer" : "50c96126-f1cd-3111-9aad-4b47b2856551",
+            "Record Reader" : "3f6a59ce-7f6d-3b1a-a0cc-441ba65b0710",
+            "/columns" : "arrayOf( /columns[*],\n  unescapeJson('{\"name\": \"_SNOWFLAKE_INSERTED_AT\", \"type\": \"TIMESTAMP_NTZ\", \"nullable\": false }'),\n  unescapeJson('{\"name\": \"_SNOWFLAKE_UPDATED_AT\", \"type\": \"TIMESTAMP_NTZ\", \"nullable\": false }'),\n  unescapeJson('{\"name\": \"_SNOWFLAKE_DELETED\", \"type\": \"BOOLEAN\", \"nullable\": true }')\n)",
+            "Replacement Value Strategy" : "record-path-value"
+          },
+          "propertyDescriptors" : {
+            "Record Writer" : {
+              "displayName" : "Record Writer",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Writer",
+              "sensitive" : false
+            },
+            "Record Reader" : {
+              "displayName" : "Record Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Reader",
+              "sensitive" : false
+            },
+            "/columns" : {
+              "displayName" : "/columns",
+              "dynamic" : true,
+              "identifiesControllerService" : false,
+              "name" : "/columns",
+              "sensitive" : false
+            },
+            "Replacement Value Strategy" : {
+              "displayName" : "Replacement Value Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Replacement Value Strategy",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "org.apache.nifi.processors.standard.UpdateRecord",
+          "yieldDuration" : "1 sec"
+        } ],
+        "remoteProcessGroups" : [ ],
+        "scheduledState" : "ENABLED",
+        "statelessFlowTimeout" : "1 min"
+      } ],
+      "processors" : [ {
+        "autoTerminatedRelationships" : [ "existing" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "67257b26-ba85-3cdf-902f-d3e1cb3cb9c7",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "PickTablesForReplication",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : -248.0
+        },
+        "properties" : {
+          "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803"
+        },
+        "propertyDescriptors" : {
+          "Table State Service" : {
+            "displayName" : "Table State Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Table State Service",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 3,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.PickTablesForReplication",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "state exists", "success" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Removes tables from the connector's list of replicating tables.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "9518432b-0194-1000-4900-bd76afc47222",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Remove Table From Replication",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : 456.0,
+          "y" : -24.0
+        },
+        "properties" : {
+          "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+          "Table Name" : "${source.table.name}",
+          "CDC Schema Registry" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+          "Desired State" : "Removed",
+          "Overwrite Existing" : "true",
+          "Schema Name" : "${source.schema.name}"
+        },
+        "propertyDescriptors" : {
+          "Table State Service" : {
+            "displayName" : "Table State Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Table State Service",
+            "sensitive" : false
+          },
+          "Table Name" : {
+            "displayName" : "Table Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Name",
+            "sensitive" : false
+          },
+          "CDC Schema Registry" : {
+            "displayName" : "CDC Schema Registry",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "CDC Schema Registry",
+            "sensitive" : false
+          },
+          "Desired State" : {
+            "displayName" : "Desired State",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Desired State",
+            "sensitive" : false
+          },
+          "Overwrite Existing" : {
+            "displayName" : "Overwrite Existing",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Overwrite Existing",
+            "sensitive" : false
+          },
+          "Schema Name" : {
+            "displayName" : "Schema Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Schema Name",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ "comms failure" ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.UpdateTableState",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "state exists" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Registers tables that have been newly added to replication, and transfers them to begin replication.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "9518432c-0194-1000-3f01-2a5546ed4dec",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Register New Tables for Replication",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : -32.0
+        },
+        "properties" : {
+          "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+          "Table Name" : "${source.table.name}",
+          "CDC Schema Registry" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+          "Desired State" : "New",
+          "Overwrite Existing" : "false",
+          "Schema Name" : "${source.schema.name}"
+        },
+        "propertyDescriptors" : {
+          "Table State Service" : {
+            "displayName" : "Table State Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Table State Service",
+            "sensitive" : false
+          },
+          "Table Name" : {
+            "displayName" : "Table Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Name",
+            "sensitive" : false
+          },
+          "CDC Schema Registry" : {
+            "displayName" : "CDC Schema Registry",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "CDC Schema Registry",
+            "sensitive" : false
+          },
+          "Desired State" : {
+            "displayName" : "Desired State",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Desired State",
+            "sensitive" : false
+          },
+          "Overwrite Existing" : {
+            "displayName" : "Overwrite Existing",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Overwrite Existing",
+            "sensitive" : false
+          },
+          "Schema Name" : {
+            "displayName" : "Schema Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Schema Name",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.UpdateTableState",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-standard-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Defines the tables or table patterns that should be included in replication.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "PRIMARY",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "9518432d-0194-1000-f6ca-34408c835ea6",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Set Tables for Replication",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : -680.0
+        },
+        "properties" : {
+          "character-set" : "UTF-8",
+          "File Size" : "0B",
+          "included.table.regex" : "#{Included Table Regex}",
+          "Batch Size" : "1",
+          "Unique FlowFiles" : "false",
+          "included.table.names" : "#{Included Table Names}",
+          "Data Format" : "Text"
+        },
+        "propertyDescriptors" : {
+          "character-set" : {
+            "displayName" : "Character Set",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "character-set",
+            "sensitive" : false
+          },
+          "File Size" : {
+            "displayName" : "File Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "File Size",
+            "sensitive" : false
+          },
+          "mime-type" : {
+            "displayName" : "Mime Type",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "mime-type",
+            "sensitive" : false
+          },
+          "included.table.regex" : {
+            "displayName" : "included.table.regex",
+            "dynamic" : true,
+            "identifiesControllerService" : false,
+            "name" : "included.table.regex",
+            "sensitive" : false
+          },
+          "generate-ff-custom-text" : {
+            "displayName" : "Custom Text",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "generate-ff-custom-text",
+            "sensitive" : false
+          },
+          "Batch Size" : {
+            "displayName" : "Batch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Batch Size",
+            "sensitive" : false
+          },
+          "Unique FlowFiles" : {
+            "displayName" : "Unique FlowFiles",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Unique FlowFiles",
+            "sensitive" : false
+          },
+          "included.table.names" : {
+            "displayName" : "included.table.names",
+            "dynamic" : true,
+            "identifiesControllerService" : false,
+            "name" : "included.table.names",
+            "sensitive" : false
+          },
+          "Data Format" : {
+            "displayName" : "Data Format",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Data Format",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "1 min",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.standard.GenerateFlowFile",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "failure" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Queries the source database for a list of accessible tables, and selects the ones configured for replication.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "9518432a-0194-1000-2796-5585af3c3bd5",
+        "identifier" : "9518432e-0194-1000-88b4-70f1cb090a2c",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Verify Configured Tables",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : -464.0
+        },
+        "properties" : {
+          "Connection Pool" : "a7df0df5-64ea-391c-9990-5b089d4eea95",
+          "Included Comma Separated Source Table Names" : "${included.table.names}",
+          "Included Source Table Pattern" : "${included.table.regex}"
+        },
+        "propertyDescriptors" : {
+          "Connection Pool" : {
+            "displayName" : "Connection Pool",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Connection Pool",
+            "sensitive" : false
+          },
+          "Included Comma Separated Source Table Names" : {
+            "displayName" : "Included Comma Separated Source Table Names",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Included Comma Separated Source Table Names",
+            "sensitive" : false
+          },
+          "Included Source Table Pattern" : {
+            "displayName" : "Included Source Table Pattern",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Included Source Table Pattern",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.ListTableNames",
+        "yieldDuration" : "1 sec"
+      } ],
+      "remoteProcessGroups" : [ ],
+      "scheduledState" : "ENABLED",
+      "statelessFlowTimeout" : "1 min"
+    }, {
+      "comments" : "Reads data from the source database's CT tables, and performs incremental replication for enabled tables.",
+      "componentType" : "PROCESS_GROUP",
+      "connections" : [ {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "111d419f-23ca-3ebd-ae09-848f0a2e0d48",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "failure" ],
+        "source" : {
+          "comments" : "Collect incoming rows into bigger FlowFiles to process them more efficiently later.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "289c53ab-2db6-36da-9b64-e0738b4e1b7e",
+          "name" : "Merge Rows Into Bigger FlowFiles",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 1,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Changes the destination table based on the incoming DDL event.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "8d987327-a28a-3ffc-b6a4-da7131c14c6e",
+          "name" : "Alter Destination Table",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "1438ed35-f304-3fbf-a38b-112c24abe68a",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "ddl" ],
+        "source" : {
+          "comments" : "Merges all pending changes from the journal table into the destination.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "bd068dd1-9370-30b6-8b27-583eba96edf2",
+          "name" : "Merge Journal to Destination",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "10 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ {
+          "x" : 208.0,
+          "y" : 919.0
+        }, {
+          "x" : 197.83447170257568,
+          "y" : 863.6417236328125
+        } ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Merges all pending changes from the journal table into the destination.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "bd068dd1-9370-30b6-8b27-583eba96edf2",
+          "name" : "Merge Journal to Destination",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "21f0c941-e9c2-37b0-8cb7-ac1355f62751",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "poll merge result",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "poll query result" ],
+        "source" : {
+          "comments" : "Merges all pending changes from the journal table into the destination.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "bd068dd1-9370-30b6-8b27-583eba96edf2",
+          "name" : "Merge Journal to Destination",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 1,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "id" : "fe558fe2-219d-3650-a294-837f6fda327a",
+          "name" : "ddl",
+          "type" : "INPUT_PORT"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "2aa28ac3-ae90-3256-a151-7e9b29bc25f9",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "schema update" ],
+        "source" : {
+          "comments" : "Handles DDL events from the CDC stream, checking whether the journal and destination table need to be updated.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "4007425d-1717-3236-ae45-ea91957f8cf2",
+          "name" : "Process Schema Changes",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "10 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Collect incoming rows into bigger FlowFiles to process them more efficiently later.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "289c53ab-2db6-36da-9b64-e0738b4e1b7e",
+          "name" : "Merge Rows Into Bigger FlowFiles",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "39ac2a09-9ee5-3079-97dc-d81623c26476",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "PARTITION_BY_ATTRIBUTE",
+        "name" : "",
+        "partitioningAttribute" : "source.table.fqn",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "Add an extra attribute to the FlowFile with the source table's Fully Qualified Name.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "bc87ae54-92e2-3a44-b97d-6fb05946e0f2",
+          "name" : "Set Source Table FQN",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "5 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Handles DDL events from the CDC stream, checking whether the journal and destination table need to be updated.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "4007425d-1717-3236-ae45-ea91957f8cf2",
+          "name" : "Process Schema Changes",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "43da8258-1a09-3987-b8ce-021d5f9c1e6d",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "merged" ],
+        "source" : {
+          "comments" : "Collect incoming rows into bigger FlowFiles to process them more efficiently later.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "289c53ab-2db6-36da-9b64-e0738b4e1b7e",
+          "name" : "Merge Rows Into Bigger FlowFiles",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "f9ec75a0-0e4d-3971-b94f-b55ec625b41e",
+          "name" : "Drop Journal Stream",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "4870574e-ff39-3d06-a7e9-785b5275dc88",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "schema change ddl" ],
+        "source" : {
+          "comments" : "Drops the first DDL FlowFile to prevent it from deleting a freshly-created journal table.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "266725de-3cee-36bf-bf80-3ffda4eac344",
+          "name" : "Drop First DDL",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 1
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ {
+          "x" : 194.96689474582672,
+          "y" : 1498.78173828125
+        }, {
+          "x" : 194.96689474582672,
+          "y" : 1548.78173828125
+        } ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "f9ec75a0-0e4d-3971-b94f-b55ec625b41e",
+          "name" : "Drop Journal Stream",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "52fbe030-5d94-33c8-b9c9-a96bc841cd44",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "failure" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "f9ec75a0-0e4d-3971-b94f-b55ec625b41e",
+          "name" : "Drop Journal Stream",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ {
+          "x" : -1240.0,
+          "y" : 1072.0
+        }, {
+          "x" : -1232.0,
+          "y" : 1144.0
+        } ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "6a3f8e33-5c6e-3c58-b10d-7235427544db",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "64c971fb-7a27-3213-82f4-ff825a5a844d",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "comms failure" ],
+        "source" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "6a3f8e33-5c6e-3c58-b10d-7235427544db",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "10 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Add an extra attribute to the FlowFile with the source table's Fully Qualified Name.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "bc87ae54-92e2-3a44-b97d-6fb05946e0f2",
+          "name" : "Set Source Table FQN",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "6a363e70-fe4f-3efb-8dce-d2630a7fef33",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "Read SQLServer Change Tracking tables for tables added to replication.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "14add69c-cc03-3c13-9302-365337291100",
+          "name" : "Read SQLServer Change Tracking tables",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Merges all pending changes from the journal table into the destination.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "bd068dd1-9370-30b6-8b27-583eba96edf2",
+          "name" : "Merge Journal to Destination",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "8f7b9802-d7bd-3a79-8e5c-bc2eaa12ae5e",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "merged" ],
+        "source" : {
+          "comments" : "Group all FlowFiles related to same table to limitate merge calls. Use this processor to schedule with cron when warehouse should be active.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "ff0fd1cc-4293-3151-aebf-7ebf79a9059c",
+          "name" : "Schedule Warehouse",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Drops the first DDL FlowFile to prevent it from deleting a freshly-created journal table.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "266725de-3cee-36bf-bf80-3ffda4eac344",
+          "name" : "Drop First DDL",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "95f9dbe8-511b-337e-a392-4583313ec76c",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "Changes the destination table based on the incoming DDL event.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "8d987327-a28a-3ffc-b6a4-da7131c14c6e",
+          "name" : "Alter Destination Table",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "a7841a16-bcf1-3fcd-9c69-f6096e43478d",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "failure" ],
+        "source" : {
+          "comments" : "Waits until the Snapshot load for a table is complete, and the connector can start merging incremental changes.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "c5295d62-536c-31d0-b1c0-523aef4bfd58",
+          "name" : "Wait for Snapshot Load to Finish",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "ac3f19ec-3ae8-3453-9ca4-3e4b96a5e074",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "failure" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "a6acbf70-0fe6-368a-a3ea-e149cb185cb8",
+          "name" : "Upload Rows via Snowpipe Streaming",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Group all FlowFiles related to same table to limitate merge calls. Use this processor to schedule with cron when warehouse should be active.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "ff0fd1cc-4293-3151-aebf-7ebf79a9059c",
+          "name" : "Schedule Warehouse",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "affac053-0624-3e18-a667-a209000eb455",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "Waits until the Snapshot load for a table is complete, and the connector can start merging incremental changes.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "c5295d62-536c-31d0-b1c0-523aef4bfd58",
+          "name" : "Wait for Snapshot Load to Finish",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "c08e6e4e-8650-3d25-a061-7e930ee8dbfa",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "failure" ],
+        "source" : {
+          "comments" : "Handles DDL events from the CDC stream, checking whether the journal and destination table need to be updated.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "4007425d-1717-3236-ae45-ea91957f8cf2",
+          "name" : "Process Schema Changes",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "10 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "a6acbf70-0fe6-368a-a3ea-e149cb185cb8",
+          "name" : "Upload Rows via Snowpipe Streaming",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "c31126e1-59c3-39de-b795-e7df2eca7201",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "Handles DDL events from the CDC stream, checking whether the journal and destination table need to be updated.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "4007425d-1717-3236-ae45-ea91957f8cf2",
+          "name" : "Process Schema Changes",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "6a3f8e33-5c6e-3c58-b10d-7235427544db",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "cf8256ac-523b-348d-a0cd-140e173e9316",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "failure", "illegal alteration", "object not found" ],
+        "source" : {
+          "comments" : "Changes the destination table based on the incoming DDL event.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "8d987327-a28a-3ffc-b6a4-da7131c14c6e",
+          "name" : "Alter Destination Table",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "de04eddd-dc26-3221-bc6f-e871da4dca83",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "failure" ],
+        "source" : {
+          "comments" : "Merges all pending changes from the journal table into the destination.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "bd068dd1-9370-30b6-8b27-583eba96edf2",
+          "name" : "Merge Journal to Destination",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "f3cda485-3b59-3a5f-8876-b6e79acd3363",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "failure" ],
+        "source" : {
+          "comments" : "Group all FlowFiles related to same table to limitate merge calls. Use this processor to schedule with cron when warehouse should be active.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "ff0fd1cc-4293-3151-aebf-7ebf79a9059c",
+          "name" : "Schedule Warehouse",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "10 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Waits until the Snapshot load for a table is complete, and the connector can start merging incremental changes.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "c5295d62-536c-31d0-b1c0-523aef4bfd58",
+          "name" : "Wait for Snapshot Load to Finish",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "f7283dee-53e1-31cd-9c39-0759e618a739",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+        "selectedRelationships" : [ "success" ],
+        "source" : {
+          "comments" : "",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "a6acbf70-0fe6-368a-a3ea-e149cb185cb8",
+          "name" : "Upload Rows via Snowpipe Streaming",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      }, {
+        "backPressureDataSizeThreshold" : "1 GB",
+        "backPressureObjectThreshold" : 10000,
+        "bends" : [ {
+          "x" : -1098.5161743164062,
+          "y" : 296.14942169189453
+        }, {
+          "x" : -1098.5161743164062,
+          "y" : 352.14942169189453
+        } ],
+        "componentType" : "CONNECTION",
+        "destination" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "flowFileExpiration" : "0 sec",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "fc8c8e69-4d4f-32e7-903c-d2d38c13334d",
+        "labelIndex" : 0,
+        "loadBalanceCompression" : "DO_NOT_COMPRESS",
+        "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+        "name" : "",
+        "partitioningAttribute" : "",
+        "prioritizers" : [ ],
+        "selectedRelationships" : [ "comms failure" ],
+        "source" : {
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "groupId" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+          "id" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+          "name" : "Mark Replication as Failed",
+          "type" : "PROCESSOR"
+        },
+        "zIndex" : 0
+      } ],
+      "controllerServices" : [ ],
+      "defaultBackPressureDataSizeThreshold" : "1 GB",
+      "defaultBackPressureObjectThreshold" : 10000,
+      "defaultFlowFileExpiration" : "0 sec",
+      "executionEngine" : "INHERITED",
+      "flowFileConcurrency" : "UNBOUNDED",
+      "flowFileOutboundPolicy" : "STREAM_WHEN_AVAILABLE",
+      "funnels" : [ ],
+      "groupIdentifier" : "flow-contents-group",
+      "identifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+      "inputPorts" : [ ],
+      "labels" : [ ],
+      "maxConcurrentTasks" : 1,
+      "name" : "Incremental Load",
+      "outputPorts" : [ ],
+      "parameterContextName" : "SQLServer Ingestion Parameters (2)",
+      "position" : {
+        "x" : -672.0,
+        "y" : -24.0
+      },
+      "processGroups" : [ {
+        "comments" : "Converts the source table schema to the journal table schema and creates in Snowflake both journal schema and table corresponding to given DDL FlowFile.",
+        "componentType" : "PROCESS_GROUP",
+        "connections" : [ {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 1,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "991d259b-0194-1000-1f21-224f7eca31b3",
+            "name" : "Mark Replication as Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "0bc69b93-a1e6-3728-b1e7-09c7781b8756",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "failure", "object exists" ],
+          "source" : {
+            "comments" : "",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "991cbe50-0194-1000-e59f-e5a1ded6edf7",
+            "name" : "Create Journal Table",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 1,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "991cbe50-0194-1000-e59f-e5a1ded6edf7",
+            "name" : "Create Journal Table",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "59c06003-82ba-3de8-abe7-a83761a8d19f",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "Creates the schema for the journal table.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "5af1781e-f239-35eb-a4f5-114cee1d6188",
+            "name" : "Create Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 1,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Converts the source table schema to the journal table schema.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "2e83fe55-7a30-3f79-805c-fab63a7bd946",
+            "name" : "Convert To Journal Schema",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "8b2202b3-c539-31d7-b35d-e9dc09f60ce5",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "" ],
+          "source" : {
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "fe558fe2-219d-3650-a294-837f6fda327a",
+            "name" : "ddl",
+            "type" : "INPUT_PORT"
+          },
+          "zIndex" : 1
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 1,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "991d259b-0194-1000-1f21-224f7eca31b3",
+            "name" : "Mark Replication as Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "ba4c6750-1cad-3775-b84a-2d85ce570323",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "Converts the source table schema to the journal table schema.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "2e83fe55-7a30-3f79-805c-fab63a7bd946",
+            "name" : "Convert To Journal Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 1,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Creates the schema for the journal table.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "5af1781e-f239-35eb-a4f5-114cee1d6188",
+            "name" : "Create Schema",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "e1100e54-c5a0-39f3-ad8b-d33c71bbb5c3",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "success" ],
+          "source" : {
+            "comments" : "Converts the source table schema to the journal table schema.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "2e83fe55-7a30-3f79-805c-fab63a7bd946",
+            "name" : "Convert To Journal Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        }, {
+          "backPressureDataSizeThreshold" : "1 GB",
+          "backPressureObjectThreshold" : 1,
+          "bends" : [ ],
+          "componentType" : "CONNECTION",
+          "destination" : {
+            "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "991d259b-0194-1000-1f21-224f7eca31b3",
+            "name" : "Mark Replication as Failed",
+            "type" : "PROCESSOR"
+          },
+          "flowFileExpiration" : "0 sec",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "e29c88d2-ae45-316e-ac8e-43f0fd59496b",
+          "labelIndex" : 0,
+          "loadBalanceCompression" : "DO_NOT_COMPRESS",
+          "loadBalanceStrategy" : "DO_NOT_LOAD_BALANCE",
+          "name" : "",
+          "partitioningAttribute" : "",
+          "prioritizers" : [ "org.apache.nifi.prioritizer.FirstInFirstOutPrioritizer" ],
+          "selectedRelationships" : [ "failure" ],
+          "source" : {
+            "comments" : "Creates the schema for the journal table.",
+            "groupId" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+            "id" : "5af1781e-f239-35eb-a4f5-114cee1d6188",
+            "name" : "Create Schema",
+            "type" : "PROCESSOR"
+          },
+          "zIndex" : 0
+        } ],
+        "controllerServices" : [ ],
+        "defaultBackPressureDataSizeThreshold" : "1 GB",
+        "defaultBackPressureObjectThreshold" : 10000,
+        "defaultFlowFileExpiration" : "0 sec",
+        "executionEngine" : "STATELESS",
+        "flowFileConcurrency" : "SINGLE_FLOWFILE_PER_NODE",
+        "flowFileOutboundPolicy" : "STREAM_WHEN_AVAILABLE",
+        "funnels" : [ ],
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+        "inputPorts" : [ {
+          "allowRemoteAccess" : false,
+          "componentType" : "INPUT_PORT",
+          "concurrentlySchedulableTaskCount" : 1,
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "fe558fe2-219d-3650-a294-837f6fda327a",
+          "name" : "ddl",
+          "portFunction" : "STANDARD",
+          "position" : {
+            "x" : 488.0,
+            "y" : 48.0
+          },
+          "scheduledState" : "ENABLED",
+          "type" : "INPUT_PORT"
+        } ],
+        "labels" : [ ],
+        "maxConcurrentTasks" : 1,
+        "name" : "Create Journal Table",
+        "outputPorts" : [ ],
+        "parameterContextName" : "SQLServer Ingestion Parameters (2)",
+        "position" : {
+          "x" : 440.0,
+          "y" : -40.0
+        },
+        "processGroups" : [ ],
+        "processors" : [ {
+          "autoTerminatedRelationships" : [ "original" ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-database-cdc-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Converts the source table schema to the journal table schema.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "2e83fe55-7a30-3f79-805c-fab63a7bd946",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Convert To Journal Schema",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : 432.0,
+            "y" : 200.0
+          },
+          "properties" : { },
+          "propertyDescriptors" : { },
+          "retriedRelationships" : [ ],
+          "retryCount" : 10,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.database.ConvertToJournalSchema",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ ],
+          "backoffMechanism" : "YIELD_PROCESSOR",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-snowflake-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Creates the schema for the journal table.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "5af1781e-f239-35eb-a4f5-114cee1d6188",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Create Schema",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : 432.0,
+            "y" : 416.0
+          },
+          "properties" : {
+            "Table Metadata Cache Expiration Time" : "30 sec",
+            "Update Type" : "Create Schema If Not Exists",
+            "Max Batch Size" : "1",
+            "Include Not Null Constraints" : "true",
+            "Table Schema Strategy" : "FlowFile Content",
+            "Schema Name" : "${source.schema.name}",
+            "Add Column Strategy" : "Alter Table",
+            "Use Table Metadata Cache" : "false",
+            "Alter Column Type Strategy" : "Fail",
+            "Column Removal Strategy" : "Drop Column",
+            "Drop Not Null Strategy" : "Alter Table",
+            "Add Not Null Strategy" : "Alter Table",
+            "Create Stream" : "false",
+            "Modify Primary Key Strategy" : "Alter Table",
+            "Drop Column Strategy" : "Alter Table",
+            "Connection Pool" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+            "Include Primary Key Constraints" : "true"
+          },
+          "propertyDescriptors" : {
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "Table Metadata Cache Expiration Time" : {
+              "displayName" : "Table Metadata Cache Expiration Time",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Metadata Cache Expiration Time",
+              "sensitive" : false
+            },
+            "Update Type" : {
+              "displayName" : "Update Type",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Update Type",
+              "sensitive" : false
+            },
+            "Max Batch Size" : {
+              "displayName" : "Max Batch Size",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Max Batch Size",
+              "sensitive" : false
+            },
+            "Include Not Null Constraints" : {
+              "displayName" : "Include Not Null Constraints",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Include Not Null Constraints",
+              "sensitive" : false
+            },
+            "Stream Creation Parameters" : {
+              "displayName" : "Stream Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Stream Creation Parameters",
+              "sensitive" : false
+            },
+            "Removed Column Name Suffix" : {
+              "displayName" : "Removed Column Name Suffix",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Removed Column Name Suffix",
+              "sensitive" : false
+            },
+            "Table Stream Creation Parameters" : {
+              "displayName" : "Table Stream Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Stream Creation Parameters",
+              "sensitive" : false
+            },
+            "Stream Name" : {
+              "displayName" : "Stream Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Stream Name",
+              "sensitive" : false
+            },
+            "Record Reader" : {
+              "displayName" : "Record Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Reader",
+              "sensitive" : false
+            },
+            "Desired Schema" : {
+              "displayName" : "Desired Schema",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Desired Schema",
+              "sensitive" : false
+            },
+            "Table Schema Strategy" : {
+              "displayName" : "Table Schema Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Schema Strategy",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            },
+            "Add Column Strategy" : {
+              "displayName" : "Add Column Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Add Column Strategy",
+              "sensitive" : false
+            },
+            "Table Stream Name" : {
+              "displayName" : "Table Stream Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Stream Name",
+              "sensitive" : false
+            },
+            "Use Table Metadata Cache" : {
+              "displayName" : "Use Table Metadata Cache",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Use Table Metadata Cache",
+              "sensitive" : false
+            },
+            "Alter Column Type Strategy" : {
+              "displayName" : "Alter Column Type Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Alter Column Type Strategy",
+              "sensitive" : false
+            },
+            "Column Removal Strategy" : {
+              "displayName" : "Column Removal Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Column Removal Strategy",
+              "sensitive" : false
+            },
+            "Column Name Transformation" : {
+              "displayName" : "Column Name Transformation",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Column Name Transformation",
+              "sensitive" : false
+            },
+            "Drop Not Null Strategy" : {
+              "displayName" : "Drop Not Null Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Drop Not Null Strategy",
+              "sensitive" : false
+            },
+            "Add Not Null Strategy" : {
+              "displayName" : "Add Not Null Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Add Not Null Strategy",
+              "sensitive" : false
+            },
+            "Creation Parameters" : {
+              "displayName" : "Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Creation Parameters",
+              "sensitive" : false
+            },
+            "Create Stream" : {
+              "displayName" : "Create Stream",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Create Stream",
+              "sensitive" : false
+            },
+            "Modify Primary Key Strategy" : {
+              "displayName" : "Modify Primary Key Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Modify Primary Key Strategy",
+              "sensitive" : false
+            },
+            "Drop Column Strategy" : {
+              "displayName" : "Drop Column Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Drop Column Strategy",
+              "sensitive" : false
+            },
+            "Connection Pool" : {
+              "displayName" : "Connection Pool",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Connection Pool",
+              "sensitive" : false
+            },
+            "Include Primary Key Constraints" : {
+              "displayName" : "Include Primary Key Constraints",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Include Primary Key Constraints",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ "failure" ],
+          "retryCount" : 100,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.snowflake.UpdateSnowflakeDatabase",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ "success" ],
+          "backoffMechanism" : "YIELD_PROCESSOR",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-snowflake-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "991cbe50-0194-1000-e59f-e5a1ded6edf7",
+          "maxBackoffPeriod" : "10 mins",
+          "name" : "Create Journal Table",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : 424.0,
+            "y" : 608.0
+          },
+          "properties" : {
+            "Table Name" : "${source.table.name}_JOURNAL_${table.schema.generation}",
+            "Table Metadata Cache Expiration Time" : "30 sec",
+            "Update Type" : "Create Table",
+            "Max Batch Size" : "1",
+            "Include Not Null Constraints" : "false",
+            "Table Stream Creation Parameters" : "APPEND_ONLY=TRUE",
+            "Table Schema Strategy" : "FlowFile Content",
+            "Schema Name" : "${source.schema.name}",
+            "Add Column Strategy" : "Alter Table",
+            "Table Stream Name" : "${source.table.name}_JOURNAL_${table.schema.generation}_STREAM",
+            "Use Table Metadata Cache" : "false",
+            "Alter Column Type Strategy" : "Fail",
+            "Column Removal Strategy" : "Drop Column",
+            "Drop Not Null Strategy" : "Alter Table",
+            "Add Not Null Strategy" : "Alter Table",
+            "Creation Parameters" : "DEFAULT_DDL_COLLATION = ''",
+            "Create Stream" : "true",
+            "Modify Primary Key Strategy" : "Alter Table",
+            "Drop Column Strategy" : "Alter Table",
+            "Connection Pool" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+            "Include Primary Key Constraints" : "false"
+          },
+          "propertyDescriptors" : {
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "Table Metadata Cache Expiration Time" : {
+              "displayName" : "Table Metadata Cache Expiration Time",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Metadata Cache Expiration Time",
+              "sensitive" : false
+            },
+            "Update Type" : {
+              "displayName" : "Update Type",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Update Type",
+              "sensitive" : false
+            },
+            "Max Batch Size" : {
+              "displayName" : "Max Batch Size",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Max Batch Size",
+              "sensitive" : false
+            },
+            "Include Not Null Constraints" : {
+              "displayName" : "Include Not Null Constraints",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Include Not Null Constraints",
+              "sensitive" : false
+            },
+            "Stream Creation Parameters" : {
+              "displayName" : "Stream Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Stream Creation Parameters",
+              "sensitive" : false
+            },
+            "Removed Column Name Suffix" : {
+              "displayName" : "Removed Column Name Suffix",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Removed Column Name Suffix",
+              "sensitive" : false
+            },
+            "Table Stream Creation Parameters" : {
+              "displayName" : "Table Stream Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Stream Creation Parameters",
+              "sensitive" : false
+            },
+            "Stream Name" : {
+              "displayName" : "Stream Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Stream Name",
+              "sensitive" : false
+            },
+            "Record Reader" : {
+              "displayName" : "Record Reader",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Record Reader",
+              "sensitive" : false
+            },
+            "Desired Schema" : {
+              "displayName" : "Desired Schema",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Desired Schema",
+              "sensitive" : false
+            },
+            "Table Schema Strategy" : {
+              "displayName" : "Table Schema Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Schema Strategy",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            },
+            "Add Column Strategy" : {
+              "displayName" : "Add Column Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Add Column Strategy",
+              "sensitive" : false
+            },
+            "Table Stream Name" : {
+              "displayName" : "Table Stream Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Stream Name",
+              "sensitive" : false
+            },
+            "Use Table Metadata Cache" : {
+              "displayName" : "Use Table Metadata Cache",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Use Table Metadata Cache",
+              "sensitive" : false
+            },
+            "Alter Column Type Strategy" : {
+              "displayName" : "Alter Column Type Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Alter Column Type Strategy",
+              "sensitive" : false
+            },
+            "Column Removal Strategy" : {
+              "displayName" : "Column Removal Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Column Removal Strategy",
+              "sensitive" : false
+            },
+            "Column Name Transformation" : {
+              "displayName" : "Column Name Transformation",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Column Name Transformation",
+              "sensitive" : false
+            },
+            "Drop Not Null Strategy" : {
+              "displayName" : "Drop Not Null Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Drop Not Null Strategy",
+              "sensitive" : false
+            },
+            "Add Not Null Strategy" : {
+              "displayName" : "Add Not Null Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Add Not Null Strategy",
+              "sensitive" : false
+            },
+            "Creation Parameters" : {
+              "displayName" : "Creation Parameters",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Creation Parameters",
+              "sensitive" : false
+            },
+            "Create Stream" : {
+              "displayName" : "Create Stream",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Create Stream",
+              "sensitive" : false
+            },
+            "Modify Primary Key Strategy" : {
+              "displayName" : "Modify Primary Key Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Modify Primary Key Strategy",
+              "sensitive" : false
+            },
+            "Drop Column Strategy" : {
+              "displayName" : "Drop Column Strategy",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Drop Column Strategy",
+              "sensitive" : false
+            },
+            "Connection Pool" : {
+              "displayName" : "Connection Pool",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Connection Pool",
+              "sensitive" : false
+            },
+            "Include Primary Key Constraints" : {
+              "displayName" : "Include Primary Key Constraints",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Include Primary Key Constraints",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ "failure" ],
+          "retryCount" : 100,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.snowflake.UpdateSnowflakeDatabase",
+          "yieldDuration" : "1 sec"
+        }, {
+          "autoTerminatedRelationships" : [ "comms failure", "state exists", "success" ],
+          "backoffMechanism" : "PENALIZE_FLOWFILE",
+          "bulletinLevel" : "WARN",
+          "bundle" : {
+            "artifact" : "runtime-database-cdc-processors-nar",
+            "group" : "com.snowflake.openflow.runtime",
+            "version" : "2025.7.24.18"
+          },
+          "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+          "componentType" : "PROCESSOR",
+          "concurrentlySchedulableTaskCount" : 1,
+          "executionNode" : "ALL",
+          "groupIdentifier" : "e9d1b30c-072f-38e6-bb8f-f346718d3d8f",
+          "identifier" : "991d259b-0194-1000-1f21-224f7eca31b3",
+          "maxBackoffPeriod" : "30 secs",
+          "name" : "Mark Replication as Failed",
+          "penaltyDuration" : "30 sec",
+          "position" : {
+            "x" : 1248.0,
+            "y" : 536.0
+          },
+          "properties" : {
+            "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+            "Table Name" : "${source.table.name}",
+            "CDC Schema Registry" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+            "Desired State" : "Failed",
+            "Overwrite Existing" : "true",
+            "Schema Name" : "${source.schema.name}"
+          },
+          "propertyDescriptors" : {
+            "Table State Service" : {
+              "displayName" : "Table State Service",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "Table State Service",
+              "sensitive" : false
+            },
+            "Table Name" : {
+              "displayName" : "Table Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Table Name",
+              "sensitive" : false
+            },
+            "CDC Schema Registry" : {
+              "displayName" : "CDC Schema Registry",
+              "dynamic" : false,
+              "identifiesControllerService" : true,
+              "name" : "CDC Schema Registry",
+              "sensitive" : false
+            },
+            "Desired State" : {
+              "displayName" : "Desired State",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Desired State",
+              "sensitive" : false
+            },
+            "Overwrite Existing" : {
+              "displayName" : "Overwrite Existing",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Overwrite Existing",
+              "sensitive" : false
+            },
+            "Schema Name" : {
+              "displayName" : "Schema Name",
+              "dynamic" : false,
+              "identifiesControllerService" : false,
+              "name" : "Schema Name",
+              "sensitive" : false
+            }
+          },
+          "retriedRelationships" : [ "comms failure" ],
+          "retryCount" : 100000,
+          "runDurationMillis" : 0,
+          "scheduledState" : "ENABLED",
+          "schedulingPeriod" : "0 sec",
+          "schedulingStrategy" : "TIMER_DRIVEN",
+          "style" : { },
+          "type" : "com.snowflake.openflow.runtime.processors.database.UpdateTableState",
+          "yieldDuration" : "1 sec"
+        } ],
+        "remoteProcessGroups" : [ ],
+        "scheduledState" : "ENABLED",
+        "statelessFlowTimeout" : "1 min"
+      } ],
+      "processors" : [ {
+        "autoTerminatedRelationships" : [ ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Read SQLServer Change Tracking tables for tables added to replication.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "PRIMARY",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "14add69c-cc03-3c13-9302-365337291100",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Read SQLServer Change Tracking tables",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : -656.0
+        },
+        "properties" : {
+          "Table State Store" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+          "Max Batch Size" : "10000",
+          "Column Filter Store" : "1d805b66-4a8a-3fb2-a7c9-0876eb122423",
+          "Connection Pool" : "a7df0df5-64ea-391c-9990-5b089d4eea95",
+          "Record Writer" : "50c96126-f1cd-3111-9aad-4b47b2856551",
+          "Fetch Size" : "100"
+        },
+        "propertyDescriptors" : {
+          "Table State Store" : {
+            "displayName" : "Table State Store",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Table State Store",
+            "sensitive" : false
+          },
+          "Max Batch Size" : {
+            "displayName" : "Max Batch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Batch Size",
+            "sensitive" : false
+          },
+          "Column Filter Store" : {
+            "displayName" : "Column Filter Store",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Column Filter Store",
+            "sensitive" : false
+          },
+          "Connection Pool" : {
+            "displayName" : "Connection Pool",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Connection Pool",
+            "sensitive" : false
+          },
+          "Record Writer" : {
+            "displayName" : "Record Writer",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Record Writer",
+            "sensitive" : false
+          },
+          "Fetch Size" : {
+            "displayName" : "Fetch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Fetch Size",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.CaptureChangeSqlServer",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "unmatched" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-standard-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Drops the first DDL FlowFile to prevent it from deleting a freshly-created journal table.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "266725de-3cee-36bf-bf80-3ffda4eac344",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Drop First DDL",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : 1264.0
+        },
+        "properties" : {
+          "Routing Strategy" : "Route to Property name",
+          "schema change ddl" : "${table.schema.initial:equals(true):not()}"
+        },
+        "propertyDescriptors" : {
+          "Routing Strategy" : {
+            "displayName" : "Routing Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Routing Strategy",
+            "sensitive" : false
+          },
+          "schema change ddl" : {
+            "displayName" : "schema change ddl",
+            "dynamic" : true,
+            "identifiesControllerService" : false,
+            "name" : "schema change ddl",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.standard.RouteOnAttribute",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "original" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-standard-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Collect incoming rows into bigger FlowFiles to process them more efficiently later.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "289c53ab-2db6-36da-9b64-e0738b4e1b7e",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Merge Rows Into Bigger FlowFiles",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : -232.0
+        },
+        "properties" : {
+          "Keep Path" : "false",
+          "Merge Strategy" : "Bin-Packing Algorithm",
+          "Attribute Strategy" : "Keep Only Common Attributes",
+          "FlowFile Insertion Strategy" : "Isolated",
+          "Compression Level" : "1",
+          "Maximum Number of Entries" : "10000",
+          "Minimum Group Size" : "0 B",
+          "Maximum number of Bins" : "1000",
+          "Tar Modified Time" : "${file.lastModifiedTime}",
+          "Delimiter Strategy" : "Text",
+          "Merge Format" : "Binary Concatenation",
+          "Max Bin Age" : "1 min",
+          "Demarcator File" : "\n",
+          "Correlation Attribute Name" : "source.table.fqn",
+          "Bin Termination Check" : "${cdc.event.type:equalsIgnoreCase('ddl')}",
+          "mergecontent-metadata-strategy" : "Do Not Merge Uncommon Metadata",
+          "Minimum Number of Entries" : "100"
+        },
+        "propertyDescriptors" : {
+          "Keep Path" : {
+            "displayName" : "Keep Path",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Keep Path",
+            "sensitive" : false
+          },
+          "Maximum Group Size" : {
+            "displayName" : "Maximum Group Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Maximum Group Size",
+            "sensitive" : false
+          },
+          "Merge Strategy" : {
+            "displayName" : "Merge Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Merge Strategy",
+            "sensitive" : false
+          },
+          "Attribute Strategy" : {
+            "displayName" : "Attribute Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Attribute Strategy",
+            "sensitive" : false
+          },
+          "FlowFile Insertion Strategy" : {
+            "displayName" : "FlowFile Insertion Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "FlowFile Insertion Strategy",
+            "sensitive" : false
+          },
+          "Compression Level" : {
+            "displayName" : "Compression Level",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Compression Level",
+            "sensitive" : false
+          },
+          "Maximum Number of Entries" : {
+            "displayName" : "Maximum Number of Entries",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Maximum Number of Entries",
+            "sensitive" : false
+          },
+          "Minimum Group Size" : {
+            "displayName" : "Minimum Group Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Minimum Group Size",
+            "sensitive" : false
+          },
+          "Maximum number of Bins" : {
+            "displayName" : "Maximum number of Bins",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Maximum number of Bins",
+            "sensitive" : false
+          },
+          "Tar Modified Time" : {
+            "displayName" : "Tar Modified Time",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Tar Modified Time",
+            "sensitive" : false
+          },
+          "Delimiter Strategy" : {
+            "displayName" : "Delimiter Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Delimiter Strategy",
+            "sensitive" : false
+          },
+          "Merge Format" : {
+            "displayName" : "Merge Format",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Merge Format",
+            "sensitive" : false
+          },
+          "Footer File" : {
+            "displayName" : "Footer",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Footer File",
+            "resourceDefinition" : {
+              "cardinality" : "SINGLE",
+              "resourceTypes" : [ "FILE", "TEXT" ]
+            },
+            "sensitive" : false
+          },
+          "Max Bin Age" : {
+            "displayName" : "Max Bin Age",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Bin Age",
+            "sensitive" : false
+          },
+          "Demarcator File" : {
+            "displayName" : "Demarcator",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Demarcator File",
+            "resourceDefinition" : {
+              "cardinality" : "SINGLE",
+              "resourceTypes" : [ "FILE", "TEXT" ]
+            },
+            "sensitive" : false
+          },
+          "Correlation Attribute Name" : {
+            "displayName" : "Correlation Attribute Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Correlation Attribute Name",
+            "sensitive" : false
+          },
+          "Bin Termination Check" : {
+            "displayName" : "Bin Termination Check",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Bin Termination Check",
+            "sensitive" : false
+          },
+          "Header File" : {
+            "displayName" : "Header",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Header File",
+            "resourceDefinition" : {
+              "cardinality" : "SINGLE",
+              "resourceTypes" : [ "FILE", "TEXT" ]
+            },
+            "sensitive" : false
+          },
+          "mergecontent-metadata-strategy" : {
+            "displayName" : "Metadata Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "mergecontent-metadata-strategy",
+            "sensitive" : false
+          },
+          "Minimum Number of Entries" : {
+            "displayName" : "Minimum Number of Entries",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Minimum Number of Entries",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.standard.MergeContent",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "skipped ddl event", "table not in state" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Handles DDL events from the CDC stream, checking whether the journal and destination table need to be updated.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "4007425d-1717-3236-ae45-ea91957f8cf2",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Process Schema Changes",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : -16.0
+        },
+        "properties" : {
+          "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+          "CDC Schema Registry" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+          "Record Writer" : "50c96126-f1cd-3111-9aad-4b47b2856551",
+          "Record Reader" : "24cdd13f-c206-3d50-bfc2-d29011a189ca"
+        },
+        "propertyDescriptors" : {
+          "Table State Service" : {
+            "displayName" : "Table State Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Table State Service",
+            "sensitive" : false
+          },
+          "CDC Schema Registry" : {
+            "displayName" : "CDC Schema Registry",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "CDC Schema Registry",
+            "sensitive" : false
+          },
+          "Record Writer" : {
+            "displayName" : "Record Writer",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Record Writer",
+            "sensitive" : false
+          },
+          "Record Reader" : {
+            "displayName" : "Record Reader",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Record Reader",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.EnrichCdcStream",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "state exists", "success" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "6a3f8e33-5c6e-3c58-b10d-7235427544db",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Mark Replication as Failed",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -1056.0,
+          "y" : 1040.0
+        },
+        "properties" : {
+          "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+          "Table Name" : "${source.table.name}",
+          "CDC Schema Registry" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+          "Desired State" : "Failed",
+          "Overwrite Existing" : "true",
+          "Schema Name" : "${source.schema.name}"
+        },
+        "propertyDescriptors" : {
+          "Table State Service" : {
+            "displayName" : "Table State Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Table State Service",
+            "sensitive" : false
+          },
+          "Table Name" : {
+            "displayName" : "Table Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Name",
+            "sensitive" : false
+          },
+          "CDC Schema Registry" : {
+            "displayName" : "CDC Schema Registry",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "CDC Schema Registry",
+            "sensitive" : false
+          },
+          "Desired State" : {
+            "displayName" : "Desired State",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Desired State",
+            "sensitive" : false
+          },
+          "Overwrite Existing" : {
+            "displayName" : "Overwrite Existing",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Overwrite Existing",
+            "sensitive" : false
+          },
+          "Schema Name" : {
+            "displayName" : "Schema Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Schema Name",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.UpdateTableState",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ ],
+        "backoffMechanism" : "YIELD_PROCESSOR",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-snowflake-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Changes the destination table based on the incoming DDL event.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "8d987327-a28a-3ffc-b6a4-da7131c14c6e",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Alter Destination Table",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : 1056.0
+        },
+        "properties" : {
+          "Table Name" : "${source.table.name}",
+          "Table Metadata Cache Expiration Time" : "30 sec",
+          "Update Type" : "Alter Table",
+          "Max Batch Size" : "1",
+          "Include Not Null Constraints" : "true",
+          "Removed Column Name Suffix" : "__SNOWFLAKE_DELETED",
+          "Desired Schema" : "${destination.table.schema}",
+          "Table Schema Strategy" : "Use 'Desired Schema' Property",
+          "Schema Name" : "${source.schema.name}",
+          "Add Column Strategy" : "Alter Table",
+          "Use Table Metadata Cache" : "false",
+          "Alter Column Type Strategy" : "Fail",
+          "Column Removal Strategy" : "Rename Column",
+          "Drop Not Null Strategy" : "Ignore",
+          "Add Not Null Strategy" : "Ignore",
+          "Create Stream" : "false",
+          "Modify Primary Key Strategy" : "Ignore",
+          "Drop Column Strategy" : "Alter Table",
+          "Connection Pool" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+          "Include Primary Key Constraints" : "true"
+        },
+        "propertyDescriptors" : {
+          "Table Name" : {
+            "displayName" : "Table Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Name",
+            "sensitive" : false
+          },
+          "Table Metadata Cache Expiration Time" : {
+            "displayName" : "Table Metadata Cache Expiration Time",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Metadata Cache Expiration Time",
+            "sensitive" : false
+          },
+          "Update Type" : {
+            "displayName" : "Update Type",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Update Type",
+            "sensitive" : false
+          },
+          "Max Batch Size" : {
+            "displayName" : "Max Batch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Batch Size",
+            "sensitive" : false
+          },
+          "Include Not Null Constraints" : {
+            "displayName" : "Include Not Null Constraints",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Include Not Null Constraints",
+            "sensitive" : false
+          },
+          "Stream Creation Parameters" : {
+            "displayName" : "Stream Creation Parameters",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Stream Creation Parameters",
+            "sensitive" : false
+          },
+          "Removed Column Name Suffix" : {
+            "displayName" : "Removed Column Name Suffix",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Removed Column Name Suffix",
+            "sensitive" : false
+          },
+          "Table Stream Creation Parameters" : {
+            "displayName" : "Table Stream Creation Parameters",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Stream Creation Parameters",
+            "sensitive" : false
+          },
+          "Stream Name" : {
+            "displayName" : "Stream Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Stream Name",
+            "sensitive" : false
+          },
+          "Record Reader" : {
+            "displayName" : "Record Reader",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Record Reader",
+            "sensitive" : false
+          },
+          "Desired Schema" : {
+            "displayName" : "Desired Schema",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Desired Schema",
+            "sensitive" : false
+          },
+          "Table Schema Strategy" : {
+            "displayName" : "Table Schema Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Schema Strategy",
+            "sensitive" : false
+          },
+          "Schema Name" : {
+            "displayName" : "Schema Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Schema Name",
+            "sensitive" : false
+          },
+          "Add Column Strategy" : {
+            "displayName" : "Add Column Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Add Column Strategy",
+            "sensitive" : false
+          },
+          "Table Stream Name" : {
+            "displayName" : "Table Stream Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Stream Name",
+            "sensitive" : false
+          },
+          "Use Table Metadata Cache" : {
+            "displayName" : "Use Table Metadata Cache",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Use Table Metadata Cache",
+            "sensitive" : false
+          },
+          "Alter Column Type Strategy" : {
+            "displayName" : "Alter Column Type Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Alter Column Type Strategy",
+            "sensitive" : false
+          },
+          "Column Removal Strategy" : {
+            "displayName" : "Column Removal Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Column Removal Strategy",
+            "sensitive" : false
+          },
+          "Column Name Transformation" : {
+            "displayName" : "Column Name Transformation",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Column Name Transformation",
+            "sensitive" : false
+          },
+          "Drop Not Null Strategy" : {
+            "displayName" : "Drop Not Null Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Drop Not Null Strategy",
+            "sensitive" : false
+          },
+          "Add Not Null Strategy" : {
+            "displayName" : "Add Not Null Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Add Not Null Strategy",
+            "sensitive" : false
+          },
+          "Creation Parameters" : {
+            "displayName" : "Creation Parameters",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Creation Parameters",
+            "sensitive" : false
+          },
+          "Create Stream" : {
+            "displayName" : "Create Stream",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Create Stream",
+            "sensitive" : false
+          },
+          "Modify Primary Key Strategy" : {
+            "displayName" : "Modify Primary Key Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Modify Primary Key Strategy",
+            "sensitive" : false
+          },
+          "Drop Column Strategy" : {
+            "displayName" : "Drop Column Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Drop Column Strategy",
+            "sensitive" : false
+          },
+          "Connection Pool" : {
+            "displayName" : "Connection Pool",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Connection Pool",
+            "sensitive" : false
+          },
+          "Include Primary Key Constraints" : {
+            "displayName" : "Include Primary Key Constraints",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Include Primary Key Constraints",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ "failure" ],
+        "retryCount" : 1000,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.snowflake.UpdateSnowflakeDatabase",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ ],
+        "backoffMechanism" : "YIELD_PROCESSOR",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-snowpipe-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 2,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "a6acbf70-0fe6-368a-a3ea-e149cb185cb8",
+        "maxBackoffPeriod" : "1 mins",
+        "name" : "Upload Rows via Snowpipe Streaming",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : 192.0
+        },
+        "properties" : {
+          "Account" : "#{Snowflake Account Identifier}",
+          "User" : "#{Snowflake Username}",
+          "Table" : "\"${source.table.name}_JOURNAL_${table.schema.generation}\"",
+          "Concurrency Group" : "${source.schema.name}.${source.table.name}",
+          "Max Batch Size" : "5000",
+          "Schema" : "\"${source.schema.name}\"",
+          "Max Tasks Per Group" : "1",
+          "Record Reader" : "24cdd13f-c206-3d50-bfc2-d29011a189ca",
+          "Iceberg Enabled" : "false",
+          "Private Key Service" : "a9d0fce7-8560-33f6-8ed0-992949862808",
+          "Connection Strategy" : "STANDARD",
+          "Role" : "#{Snowflake Role}",
+          "Snowpipe Channel Prefix" : "${source.schema.name}.${source.table.name}",
+          "Client Lag" : "1 sec",
+          "Authentication Strategy" : "#{Snowflake Authentication Strategy}",
+          "Delivery Guarantee" : "At least once",
+          "Database" : "DATA_NPI"
+        },
+        "propertyDescriptors" : {
+          "Account" : {
+            "displayName" : "Account",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Account",
+            "sensitive" : false
+          },
+          "User" : {
+            "displayName" : "User",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "User",
+            "sensitive" : false
+          },
+          "Table" : {
+            "displayName" : "Table",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table",
+            "sensitive" : false
+          },
+          "Concurrency Group" : {
+            "displayName" : "Concurrency Group",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Concurrency Group",
+            "sensitive" : false
+          },
+          "Max Batch Size" : {
+            "displayName" : "Max Batch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Batch Size",
+            "sensitive" : false
+          },
+          "Schema" : {
+            "displayName" : "Schema",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Schema",
+            "sensitive" : false
+          },
+          "Max Tasks Per Group" : {
+            "displayName" : "Max Tasks Per Group",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Tasks Per Group",
+            "sensitive" : false
+          },
+          "Record Offset" : {
+            "displayName" : "Record Offset",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Record Offset",
+            "sensitive" : false
+          },
+          "Record Reader" : {
+            "displayName" : "Record Reader",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Record Reader",
+            "sensitive" : false
+          },
+          "Iceberg Enabled" : {
+            "displayName" : "Iceberg Enabled",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Iceberg Enabled",
+            "sensitive" : false
+          },
+          "Snowpipe Channel Index" : {
+            "displayName" : "Snowpipe Channel Index",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Snowpipe Channel Index",
+            "sensitive" : false
+          },
+          "Private Key Service" : {
+            "displayName" : "Private Key Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Private Key Service",
+            "sensitive" : false
+          },
+          "Connection Strategy" : {
+            "displayName" : "Connection Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Connection Strategy",
+            "sensitive" : false
+          },
+          "Role" : {
+            "displayName" : "Role",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Role",
+            "sensitive" : false
+          },
+          "Record Offset Strategy" : {
+            "displayName" : "Record Offset Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Record Offset Strategy",
+            "sensitive" : false
+          },
+          "Snowpipe Channel Prefix" : {
+            "displayName" : "Snowpipe Channel Prefix",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Snowpipe Channel Prefix",
+            "sensitive" : false
+          },
+          "Client Lag" : {
+            "displayName" : "Client Lag",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Client Lag",
+            "sensitive" : false
+          },
+          "Authentication Strategy" : {
+            "displayName" : "Authentication Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Authentication Strategy",
+            "sensitive" : false
+          },
+          "Delivery Guarantee" : {
+            "displayName" : "Delivery Guarantee",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Delivery Guarantee",
+            "sensitive" : false
+          },
+          "Record Offset Record Path" : {
+            "displayName" : "Record Offset Record Path",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Record Offset Record Path",
+            "sensitive" : false
+          },
+          "Database" : {
+            "displayName" : "Database",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Database",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ "failure" ],
+        "retryCount" : 300000,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.snowpipe.PutSnowpipeStreaming",
+        "yieldDuration" : "10 millis"
+      }, {
+        "autoTerminatedRelationships" : [ "state exists", "success" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Change the replication state of the table to permanently failed, requiring manual intervention.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "aff0ad6f-33e3-334a-b787-e3afd96fc500",
+        "maxBackoffPeriod" : "30 secs",
+        "name" : "Mark Replication as Failed",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -976.0,
+          "y" : 256.0
+        },
+        "properties" : {
+          "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+          "Table Name" : "${source.table.name}",
+          "CDC Schema Registry" : "a72a2452-e286-3ab0-a350-c1f7d6eb09ed",
+          "Desired State" : "Failed",
+          "Overwrite Existing" : "true",
+          "Schema Name" : "${source.schema.name}"
+        },
+        "propertyDescriptors" : {
+          "Table State Service" : {
+            "displayName" : "Table State Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Table State Service",
+            "sensitive" : false
+          },
+          "Table Name" : {
+            "displayName" : "Table Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Name",
+            "sensitive" : false
+          },
+          "CDC Schema Registry" : {
+            "displayName" : "CDC Schema Registry",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "CDC Schema Registry",
+            "sensitive" : false
+          },
+          "Desired State" : {
+            "displayName" : "Desired State",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Desired State",
+            "sensitive" : false
+          },
+          "Overwrite Existing" : {
+            "displayName" : "Overwrite Existing",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Overwrite Existing",
+            "sensitive" : false
+          },
+          "Schema Name" : {
+            "displayName" : "Schema Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Schema Name",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ "comms failure" ],
+        "retryCount" : 10000,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.UpdateTableState",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-update-attribute-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Add an extra attribute to the FlowFile with the source table's Fully Qualified Name.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "bc87ae54-92e2-3a44-b97d-6fb05946e0f2",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Set Source Table FQN",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : -440.0
+        },
+        "properties" : {
+          "Store State" : "Do not store state",
+          "canonical-value-lookup-cache-size" : "100",
+          "source.table.fqn" : "${source.schema.name}.${source.table.name}"
+        },
+        "propertyDescriptors" : {
+          "Delete Attributes Expression" : {
+            "displayName" : "Delete Attributes Expression",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Delete Attributes Expression",
+            "sensitive" : false
+          },
+          "Store State" : {
+            "displayName" : "Store State",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Store State",
+            "sensitive" : false
+          },
+          "canonical-value-lookup-cache-size" : {
+            "displayName" : "Cache Value Lookup Cache Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "canonical-value-lookup-cache-size",
+            "sensitive" : false
+          },
+          "source.table.fqn" : {
+            "displayName" : "source.table.fqn",
+            "dynamic" : true,
+            "identifiesControllerService" : false,
+            "name" : "source.table.fqn",
+            "sensitive" : false
+          },
+          "Stateful Variables Initial Value" : {
+            "displayName" : "Stateful Variables Initial Value",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Stateful Variables Initial Value",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.attributes.UpdateAttribute",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "deleted during compaction", "failure retry", "success", "unknown file type" ],
+        "backoffMechanism" : "YIELD_PROCESSOR",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Merges all pending changes from the journal table into the destination.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 4,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "bd068dd1-9370-30b6-8b27-583eba96edf2",
+        "maxBackoffPeriod" : "30 sec",
+        "name" : "Merge Journal to Destination",
+        "penaltyDuration" : "5 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : 848.0
+        },
+        "properties" : {
+          "Merge Query Retry Count" : "10000",
+          "Record Reader" : "24cdd13f-c206-3d50-bfc2-d29011a189ca",
+          "Snowflake Connection Pool" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+          "Destination Database Name" : "DATA_NPI"
+        },
+        "propertyDescriptors" : {
+          "Merge Query Retry Count" : {
+            "displayName" : "Merge Query Retry Count",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Merge Query Retry Count",
+            "sensitive" : false
+          },
+          "Record Reader" : {
+            "displayName" : "Record Reader",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Record Reader",
+            "sensitive" : false
+          },
+          "Snowflake Connection Pool" : {
+            "displayName" : "Snowflake Connection Pool",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Snowflake Connection Pool",
+            "sensitive" : false
+          },
+          "Destination Database Name" : {
+            "displayName" : "Destination Database Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Destination Database Name",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ "failure retry" ],
+        "retryCount" : 10000,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.MergeSnowflakeJournalTable",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-database-cdc-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Waits until the Snapshot load for a table is complete, and the connector can start merging incremental changes.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "c5295d62-536c-31d0-b1c0-523aef4bfd58",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Wait for Snapshot Load to Finish",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -274.0,
+          "y" : 412.5
+        },
+        "properties" : {
+          "Table State Service" : "bff543d5-cd9c-351a-aed7-363735fb0803",
+          "Accepted State" : "INCREMENTAL_REPLICATION"
+        },
+        "propertyDescriptors" : {
+          "Table State Service" : {
+            "displayName" : "Table State Service",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Table State Service",
+            "sensitive" : false
+          },
+          "Accepted State" : {
+            "displayName" : "Accepted State",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Accepted State",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.database.WaitForTableState",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "object not found", "success" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "runtime-snowflake-processors-nar",
+          "group" : "com.snowflake.openflow.runtime",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "f9ec75a0-0e4d-3971-b94f-b55ec625b41e",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Drop Journal Stream",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -280.0,
+          "y" : 1464.0
+        },
+        "properties" : {
+          "Table Metadata Cache Expiration Time" : "30 sec",
+          "Update Type" : "Drop Stream",
+          "Max Batch Size" : "1",
+          "Include Not Null Constraints" : "true",
+          "Stream Name" : "${source.table.name}_JOURNAL_${table.schema.generation}_STREAM",
+          "Table Schema Strategy" : "FlowFile Content",
+          "Schema Name" : "${source.schema.name}",
+          "Add Column Strategy" : "Alter Table",
+          "Use Table Metadata Cache" : "false",
+          "Alter Column Type Strategy" : "Fail",
+          "Column Removal Strategy" : "Drop Column",
+          "Drop Not Null Strategy" : "Alter Table",
+          "Add Not Null Strategy" : "Alter Table",
+          "Create Stream" : "false",
+          "Modify Primary Key Strategy" : "Alter Table",
+          "Drop Column Strategy" : "Alter Table",
+          "Connection Pool" : "7953bc13-7d05-31c3-90ec-789465030bbf",
+          "Include Primary Key Constraints" : "true"
+        },
+        "propertyDescriptors" : {
+          "Table Name" : {
+            "displayName" : "Table Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Name",
+            "sensitive" : false
+          },
+          "Table Metadata Cache Expiration Time" : {
+            "displayName" : "Table Metadata Cache Expiration Time",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Metadata Cache Expiration Time",
+            "sensitive" : false
+          },
+          "Update Type" : {
+            "displayName" : "Update Type",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Update Type",
+            "sensitive" : false
+          },
+          "Max Batch Size" : {
+            "displayName" : "Max Batch Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Batch Size",
+            "sensitive" : false
+          },
+          "Include Not Null Constraints" : {
+            "displayName" : "Include Not Null Constraints",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Include Not Null Constraints",
+            "sensitive" : false
+          },
+          "Stream Creation Parameters" : {
+            "displayName" : "Stream Creation Parameters",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Stream Creation Parameters",
+            "sensitive" : false
+          },
+          "Removed Column Name Suffix" : {
+            "displayName" : "Removed Column Name Suffix",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Removed Column Name Suffix",
+            "sensitive" : false
+          },
+          "Table Stream Creation Parameters" : {
+            "displayName" : "Table Stream Creation Parameters",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Stream Creation Parameters",
+            "sensitive" : false
+          },
+          "Stream Name" : {
+            "displayName" : "Stream Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Stream Name",
+            "sensitive" : false
+          },
+          "Record Reader" : {
+            "displayName" : "Record Reader",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Record Reader",
+            "sensitive" : false
+          },
+          "Desired Schema" : {
+            "displayName" : "Desired Schema",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Desired Schema",
+            "sensitive" : false
+          },
+          "Table Schema Strategy" : {
+            "displayName" : "Table Schema Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Schema Strategy",
+            "sensitive" : false
+          },
+          "Schema Name" : {
+            "displayName" : "Schema Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Schema Name",
+            "sensitive" : false
+          },
+          "Add Column Strategy" : {
+            "displayName" : "Add Column Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Add Column Strategy",
+            "sensitive" : false
+          },
+          "Table Stream Name" : {
+            "displayName" : "Table Stream Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Table Stream Name",
+            "sensitive" : false
+          },
+          "Use Table Metadata Cache" : {
+            "displayName" : "Use Table Metadata Cache",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Use Table Metadata Cache",
+            "sensitive" : false
+          },
+          "Alter Column Type Strategy" : {
+            "displayName" : "Alter Column Type Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Alter Column Type Strategy",
+            "sensitive" : false
+          },
+          "Column Removal Strategy" : {
+            "displayName" : "Column Removal Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Column Removal Strategy",
+            "sensitive" : false
+          },
+          "Column Name Transformation" : {
+            "displayName" : "Column Name Transformation",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Column Name Transformation",
+            "sensitive" : false
+          },
+          "Drop Not Null Strategy" : {
+            "displayName" : "Drop Not Null Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Drop Not Null Strategy",
+            "sensitive" : false
+          },
+          "Add Not Null Strategy" : {
+            "displayName" : "Add Not Null Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Add Not Null Strategy",
+            "sensitive" : false
+          },
+          "Creation Parameters" : {
+            "displayName" : "Creation Parameters",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Creation Parameters",
+            "sensitive" : false
+          },
+          "Create Stream" : {
+            "displayName" : "Create Stream",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Create Stream",
+            "sensitive" : false
+          },
+          "Modify Primary Key Strategy" : {
+            "displayName" : "Modify Primary Key Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Modify Primary Key Strategy",
+            "sensitive" : false
+          },
+          "Drop Column Strategy" : {
+            "displayName" : "Drop Column Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Drop Column Strategy",
+            "sensitive" : false
+          },
+          "Connection Pool" : {
+            "displayName" : "Connection Pool",
+            "dynamic" : false,
+            "identifiesControllerService" : true,
+            "name" : "Connection Pool",
+            "sensitive" : false
+          },
+          "Include Primary Key Constraints" : {
+            "displayName" : "Include Primary Key Constraints",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Include Primary Key Constraints",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "0 sec",
+        "schedulingStrategy" : "TIMER_DRIVEN",
+        "style" : { },
+        "type" : "com.snowflake.openflow.runtime.processors.snowflake.UpdateSnowflakeDatabase",
+        "yieldDuration" : "1 sec"
+      }, {
+        "autoTerminatedRelationships" : [ "original" ],
+        "backoffMechanism" : "PENALIZE_FLOWFILE",
+        "bulletinLevel" : "WARN",
+        "bundle" : {
+          "artifact" : "nifi-standard-nar",
+          "group" : "org.apache.nifi",
+          "version" : "2025.7.24.18"
+        },
+        "comments" : "Group all FlowFiles related to same table to limitate merge calls. Use this processor to schedule with cron when warehouse should be active.",
+        "componentType" : "PROCESSOR",
+        "concurrentlySchedulableTaskCount" : 1,
+        "executionNode" : "ALL",
+        "groupIdentifier" : "ac5c9d08-cfe4-3e8b-9e4b-29e93e729049",
+        "identifier" : "ff0fd1cc-4293-3151-aebf-7ebf79a9059c",
+        "maxBackoffPeriod" : "10 mins",
+        "name" : "Schedule Warehouse",
+        "penaltyDuration" : "30 sec",
+        "position" : {
+          "x" : -272.0,
+          "y" : 624.0
+        },
+        "properties" : {
+          "Keep Path" : "false",
+          "Merge Strategy" : "Bin-Packing Algorithm",
+          "Attribute Strategy" : "Keep Only Common Attributes",
+          "FlowFile Insertion Strategy" : "Isolated",
+          "Compression Level" : "1",
+          "Maximum Number of Entries" : "10000000",
+          "Minimum Group Size" : "0 B",
+          "Maximum number of Bins" : "1000",
+          "Tar Modified Time" : "${file.lastModifiedTime}",
+          "Delimiter Strategy" : "Text",
+          "Merge Format" : "Binary Concatenation",
+          "Max Bin Age" : "10s",
+          "Correlation Attribute Name" : "source.table.fqn",
+          "Bin Termination Check" : "${cdc.event.type:equalsIgnoreCase('ddl')}",
+          "mergecontent-metadata-strategy" : "Do Not Merge Uncommon Metadata",
+          "Minimum Number of Entries" : "1"
+        },
+        "propertyDescriptors" : {
+          "Keep Path" : {
+            "displayName" : "Keep Path",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Keep Path",
+            "sensitive" : false
+          },
+          "Maximum Group Size" : {
+            "displayName" : "Maximum Group Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Maximum Group Size",
+            "sensitive" : false
+          },
+          "Merge Strategy" : {
+            "displayName" : "Merge Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Merge Strategy",
+            "sensitive" : false
+          },
+          "Attribute Strategy" : {
+            "displayName" : "Attribute Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Attribute Strategy",
+            "sensitive" : false
+          },
+          "FlowFile Insertion Strategy" : {
+            "displayName" : "FlowFile Insertion Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "FlowFile Insertion Strategy",
+            "sensitive" : false
+          },
+          "Compression Level" : {
+            "displayName" : "Compression Level",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Compression Level",
+            "sensitive" : false
+          },
+          "Maximum Number of Entries" : {
+            "displayName" : "Maximum Number of Entries",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Maximum Number of Entries",
+            "sensitive" : false
+          },
+          "Minimum Group Size" : {
+            "displayName" : "Minimum Group Size",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Minimum Group Size",
+            "sensitive" : false
+          },
+          "Maximum number of Bins" : {
+            "displayName" : "Maximum number of Bins",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Maximum number of Bins",
+            "sensitive" : false
+          },
+          "Tar Modified Time" : {
+            "displayName" : "Tar Modified Time",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Tar Modified Time",
+            "sensitive" : false
+          },
+          "Delimiter Strategy" : {
+            "displayName" : "Delimiter Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Delimiter Strategy",
+            "sensitive" : false
+          },
+          "Merge Format" : {
+            "displayName" : "Merge Format",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Merge Format",
+            "sensitive" : false
+          },
+          "Footer File" : {
+            "displayName" : "Footer",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Footer File",
+            "resourceDefinition" : {
+              "cardinality" : "SINGLE",
+              "resourceTypes" : [ "FILE", "TEXT" ]
+            },
+            "sensitive" : false
+          },
+          "Max Bin Age" : {
+            "displayName" : "Max Bin Age",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Max Bin Age",
+            "sensitive" : false
+          },
+          "Demarcator File" : {
+            "displayName" : "Demarcator",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Demarcator File",
+            "resourceDefinition" : {
+              "cardinality" : "SINGLE",
+              "resourceTypes" : [ "FILE", "TEXT" ]
+            },
+            "sensitive" : false
+          },
+          "Correlation Attribute Name" : {
+            "displayName" : "Correlation Attribute Name",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Correlation Attribute Name",
+            "sensitive" : false
+          },
+          "Bin Termination Check" : {
+            "displayName" : "Bin Termination Check",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Bin Termination Check",
+            "sensitive" : false
+          },
+          "Header File" : {
+            "displayName" : "Header",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Header File",
+            "resourceDefinition" : {
+              "cardinality" : "SINGLE",
+              "resourceTypes" : [ "FILE", "TEXT" ]
+            },
+            "sensitive" : false
+          },
+          "mergecontent-metadata-strategy" : {
+            "displayName" : "Metadata Strategy",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "mergecontent-metadata-strategy",
+            "sensitive" : false
+          },
+          "Minimum Number of Entries" : {
+            "displayName" : "Minimum Number of Entries",
+            "dynamic" : false,
+            "identifiesControllerService" : false,
+            "name" : "Minimum Number of Entries",
+            "sensitive" : false
+          }
+        },
+        "retriedRelationships" : [ ],
+        "retryCount" : 10,
+        "runDurationMillis" : 0,
+        "scheduledState" : "ENABLED",
+        "schedulingPeriod" : "#{Merge Task Schedule CRON}",
+        "schedulingStrategy" : "CRON_DRIVEN",
+        "style" : { },
+        "type" : "org.apache.nifi.processors.standard.MergeContent",
+        "yieldDuration" : "1 sec"
+      } ],
+      "remoteProcessGroups" : [ ],
+      "scheduledState" : "ENABLED",
+      "statelessFlowTimeout" : "1 min"
+    } ],
+    "processors" : [ ],
+    "remoteProcessGroups" : [ ],
+    "scheduledState" : "ENABLED",
+    "statelessFlowTimeout" : "1 min"
+  },
+  "flowEncodingVersion" : "1.0",
+  "latest" : false,
+  "parameterContexts" : {
+    "SQLServer Destination Parameters" : {
+      "componentType" : "PARAMETER_CONTEXT",
+      "inheritedParameterContexts" : [ ],
+      "name" : "SQLServer Destination Parameters",
+      "parameters" : [ {
+        "description" : "The database where data will be persisted. It must already exist in Snowflake",
+        "name" : "Destination Database",
+        "provided" : false,
+        "sensitive" : false,
+        "value" : "DEV_DATALAKE"
+      }, {
+        "description" : "Snowflake account name formatted as [organization-name]-[account-name] where data will be persisted",
+        "name" : "Snowflake Account Identifier",
+        "provided" : false,
+        "sensitive" : false
+      }, {
+        "description" : "Strategy of authentication to Snowflake. Possible values: SNOWFLAKE_SESSION_TOKEN - when we are running flow on SPCS, KEY_PAIR when we want to setup access using private key",
+        "name" : "Snowflake Authentication Strategy",
+        "provided" : false,
+        "sensitive" : false,
+        "value" : "KEY_PAIR"
+      }, {
+        "description" : "The RSA private key which is used for authentication. The RSA key must be formatted according to PKCS8 standards and have standard PEM headers and footers. Note that either Snowflake Private Key File or Snowflake Private Key must be defined",
+        "name" : "Snowflake Private Key",
+        "provided" : false,
+        "sensitive" : true
+      }, {
+        "description" : "The file that contains the RSA Private Key used for authentication to Snowflake, formatted according to PKCS8 standards and having standard PEM headers and footers. The header line starts with -----BEGIN PRIVATE",
+        "name" : "Snowflake Private Key File",
+        "provided" : false,
+        "sensitive" : false
+      }, {
+        "description" : "The password associated with the Snowflake Private Key File",
+        "name" : "Snowflake Private Key Password",
+        "provided" : false,
+        "sensitive" : true
+      }, {
+        "description" : "Snowflake Role used during query execution",
+        "name" : "Snowflake Role",
+        "provided" : false,
+        "sensitive" : false
+      }, {
+        "description" : "User name used to connect to Snowflake instance",
+        "name" : "Snowflake Username",
+        "provided" : false,
+        "sensitive" : false
+      }, {
+        "description" : "Snowflake warehouse used to run queries",
+        "name" : "Snowflake Warehouse",
+        "provided" : false,
+        "sensitive" : false
+      } ]
+    },
+    "SQLServer Ingestion Parameters (2)" : {
+      "componentType" : "PARAMETER_CONTEXT",
+      "inheritedParameterContexts" : [ "SQLServer Destination Parameters", "SQLServer Source Parameters" ],
+      "name" : "SQLServer Ingestion Parameters (2)",
+      "parameters" : [ {
+        "description" : "A JSON specifying which columns and column patterns should be included or excluded from replication, per table. Takes the form of an array with one object per table, e.g. [ {\"schema\":\"public\", \"table\":\"table1\", \"includedPattern\":\".*name\"} ] - this will include all columns that end with 'name' in the 'table1' from the 'public' schema",
+        "name" : "Column Filter JSON",
+        "provided" : false,
+        "sensitive" : false,
+        "value" : "[]"
+      }, {
+        "description" : "A comma-separated list of fully-qualified table names that should be replicated. The format should be <schema name>.<table name>. For example: public.table1, public.table2, public.table3",
+        "name" : "Included Table Names",
+        "provided" : false,
+        "sensitive" : false
+      }, {
+        "description" : "A Regular Expression that can be matched against table names to determine if the table should be included. The Regular Expression should match the fully qualified table name. For example, to include all tables in the \"snowflake\" schema, use snowflake\\..*",
+        "name" : "Included Table Regex",
+        "provided" : false,
+        "sensitive" : false
+      }, {
+        "description" : "CRON expression defining periods when merge operations from Journal to Destination Table will be triggered. Set it to * * * * * ? if you want to have continuous merge or time schedule to limitate warehouse run time.\nFor example:\n• The string * 0 * * * ? indicates that you want to schedule merges at full hour for one minute\n• The string * 20 14 ? * MON-FRI indicates that you want to schedule merges at 2:20 PM every Monday through Friday.\nFor additional information and examples, see the cron triggers tutorial in the Quartz Documentation https://www.quartz-scheduler.org/documentation/quartz-2.2.2/tutorials/tutorial-lesson-06.html",
+        "name" : "Merge Task Schedule CRON",
+        "provided" : false,
+        "sensitive" : false,
+        "value" : "* * * * * ?"
+      } ]
+    },
+    "SQLServer Source Parameters" : {
+      "componentType" : "PARAMETER_CONTEXT",
+      "inheritedParameterContexts" : [ ],
+      "name" : "SQLServer Source Parameters",
+      "parameters" : [ {
+        "description" : "The JDBC Connection URL",
+        "name" : "SQLServer Connection URL",
+        "provided" : false,
+        "sensitive" : false,
+        "value" : "jdbc:sqlserver://<hostname>:1433;encrypt=false"
+      }, {
+        "description" : "The JDBC Driver JAR File reference. Download the jar from its website, then select the 'Reference asset' checkbox to upload and attach it.",
+        "name" : "SQLServer JDBC Driver",
+        "provided" : false,
+        "sensitive" : false
+      }, {
+        "description" : "The password for interacting with SQLServer",
+        "name" : "SQLServer Password",
+        "provided" : false,
+        "sensitive" : true
+      }, {
+        "description" : "The username for interacting with SQLServer",
+        "name" : "SQLServer Username",
+        "provided" : false,
+        "sensitive" : false
+      } ]
+    }
+  },
+  "parameterProviders" : { },
+  "snapshotMetadata" : {
+    "author" : "RAJENDRASANCHINA",
+    "flowIdentifier" : "NPI",
+    "timestamp" : 1753953463000
+  }
+}


### PR DESCRIPTION
Create a new Snowflake OpenFlow configuration file (`NPI.json`) to replicate data to the `DATA_NPI` database.

This file is a copy of the existing `CMSDBO.json` configuration, with all flow identifiers, names, and database references updated from `CMSDBO` or a parameter to `NPI` and `DATA_NPI` respectively.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cf15094-ce2b-405b-a524-b4fbbb638d58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3cf15094-ce2b-405b-a524-b4fbbb638d58">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>